### PR TITLE
Updating relative paths to Windows 10 SDK to absolute paths.

### DIFF
--- a/ButtplugUWPBluetoothManager/ButtplugUWPBluetoothManager.csproj
+++ b/ButtplugUWPBluetoothManager/ButtplugUWPBluetoothManager.csproj
@@ -37,11 +37,11 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
+      <HintPath>c:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
+      <HintPath>c:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/ButtplugUWPGamepadManager/ButtplugUWPGamepadManager.csproj
+++ b/ButtplugUWPGamepadManager/ButtplugUWPGamepadManager.csproj
@@ -33,7 +33,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
+      <HintPath>c:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This means that whilst you must have the Windows 10 SDK
(specifically 10.0.15063.0) installed in the default location of
C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0,
everything should build regardless of where the project is located
in your filesystem.