### PR TITLE
Adding schema checking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "raven-csharp"]
 	path = raven-csharp
 	url = https://github.com/qdot/raven-csharp
+[submodule "buttplug-schema"]
+	path = buttplug-schema
+	url = https://github.com/metafetish/buttplug

--- a/Buttplug/Buttplug.csproj
+++ b/Buttplug/Buttplug.csproj
@@ -39,6 +39,9 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json.Schema, Version=3.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.Schema.3.0.1\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -75,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <EmbeddedResource Include="..\buttplug-schema\schema\buttplug-schema.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Buttplug/packages.config
+++ b/Buttplug/packages.config
@@ -4,4 +4,5 @@
   <package id="LibLog" version="4.2.6" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json.Schema" version="3.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This change adds the buttplug repo as a submodule at buttplug-schema and sets the schema an an embedded resource. It uses the Newtonsoft Json.Net Schema library to perform the validation (satisfying #79). Unfortunately, there is a bug in the schema that will case the tests to fail, so the submodule will probably need to be updated once https://github.com/metafetish/buttplug/pull/15 has been accepted.