### PR TITLE
Adding a localOnly flag to the logging methods

### DIFF
--- a/Buttplug/Core/ButtplugJSONMessageParser.cs
+++ b/Buttplug/Core/ButtplugJSONMessageParser.cs
@@ -130,21 +130,23 @@ namespace Buttplug.Core
 
         public string Serialize(ButtplugMessage aMsg)
         {
-            // Warning: Do not put any log messages in this function. They will possibly recurse.
+            // Warning: Any log messages in this function must be localOnly. They will possibly recurse.
             var o = new JObject(new JProperty(aMsg.GetType().Name, JObject.FromObject(aMsg)));
             var a = new JArray(o);
+            _bpLogger.Trace($"Message serialized to: {a.ToString(Formatting.None)}", true);
             return a.ToString(Formatting.None);
         }
 
         public string Serialize(ButtplugMessage[] aMsgs)
         {
-            // Warning: Do not put any log messages in this function. They will possibly recurse.
+            // Warning: Any log messages in this function must be localOnly. They will possibly recurse.
             var a = new JArray();
             foreach (ButtplugMessage aMsg in aMsgs)
             {
                 var o = new JObject(new JProperty(aMsg.GetType().Name, JObject.FromObject(aMsg)));
                 a.Add(o);
             }
+            _bpLogger.Trace($"Message serialized to: {a.ToString(Formatting.None)}", true);
             return a.ToString(Formatting.None);
         }
     }

--- a/Buttplug/Core/ButtplugLog.cs
+++ b/Buttplug/Core/ButtplugLog.cs
@@ -16,51 +16,69 @@ namespace Buttplug.Core
             _log = aLogger;
         }
 
-        public void Trace(string aMsg)
+        public void Trace(string aMsg, bool localOnly)
         {
             _log.Trace(aMsg);
-            LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Trace, aMsg));
+            if (!localOnly)
+            {
+                LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Trace, aMsg));
+            }
         }
 
-        public void Debug(string aMsg)
+        public void Debug(string aMsg, bool localOnly)
         {
             _log.Debug(aMsg);
-            LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Debug, aMsg));
+            if (!localOnly)
+            {
+                LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Debug, aMsg));
+            }
         }
-         
-        public void Info(string aMsg)
+
+        public void Info(string aMsg, bool localOnly)
         {
             _log.Info(aMsg);
-            LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Info, aMsg));
+            if (!localOnly)
+            {
+                LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Info, aMsg));
+            }
         }
 
-        public void Warn(string aMsg)
+        public void Warn(string aMsg, bool localOnly)
         {
             _log.Warn(aMsg);
-            LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Warn, aMsg));
+            if (!localOnly)
+            {
+                LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Warn, aMsg));
+            }
         }
 
-        public void Error(string aMsg)
+        public void Error(string aMsg, bool localOnly)
         {
             _log.Error(aMsg);
-            LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Error, aMsg));
+            if (!localOnly)
+            {
+                LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Error, aMsg));
+            }
         }
 
-        public void Fatal(string aMsg)
+        public void Fatal(string aMsg, bool localOnly)
         {
             _log.Fatal(aMsg);
-            LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Fatal, aMsg));
+            if (!localOnly)
+            {
+                LogMessageReceived?.Invoke(this, new ButtplugLogMessageEventArgs(ButtplugLogLevel.Fatal, aMsg));
+            }
         }
 
         public Error LogErrorMsg(uint aId, string msg)
         {
-            Error(msg);
+            Error(msg, false);
             return new Error(msg, aId);
         }
 
         public Error LogWarnMsg(uint aId, string msg)
         {
-            Warn(msg);
+            Warn(msg, false);
             return new Error(msg, aId);
         }
     }

--- a/Buttplug/Core/IButtplugLog.cs
+++ b/Buttplug/Core/IButtplugLog.cs
@@ -8,12 +8,12 @@ namespace Buttplug.Core
     {
         [CanBeNull]
         event EventHandler<ButtplugLogMessageEventArgs> LogMessageReceived;
-        void Trace(string aMsg);
-        void Debug(string aMsg);
-        void Info(string aMsg);
-        void Warn(string aMsg);
-        void Error(string aMsg);
-        void Fatal(string aMsg);
+        void Trace(string aMsg, bool localOnly = false);
+        void Debug(string aMsg, bool localOnly = false);
+        void Info(string aMsg, bool localOnly = false);
+        void Warn(string aMsg, bool localOnly = false);
+        void Error(string aMsg, bool localOnly = false);
+        void Fatal(string aMsg, bool localOnly = false);
         [NotNull]
         Error LogErrorMsg(uint aId, string aMsg);
         [NotNull]

--- a/ButtplugTest/Core/TestService.cs
+++ b/ButtplugTest/Core/TestService.cs
@@ -3,12 +3,15 @@ using Buttplug.Messages;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using System.Collections.Generic;
 using Xunit;
 
 namespace ButtplugTest.Core
 {
     internal class TestService : ButtplugService
     {
+        public List<string> outgoingAsync = new List<string>();
+
         public TestService() : base("Test Service", 100)
         {
             // Build ourselves an NLog manager just so we can see what's going on.
@@ -22,6 +25,11 @@ namespace ButtplugTest.Core
             var t = SendMessage(new RequestServerInfo("TestClient"));
             t.Wait();
             Assert.True(t.Result is ServerInfo);
+        }
+
+        public void OnMessageReceived(object aObj, MessageReceivedEventArgs e)
+        {
+            outgoingAsync.Add(Serialize(e.Message));
         }
     }
 }

--- a/ButtplugTest/Messages/ButtplugMessage.cs
+++ b/ButtplugTest/Messages/ButtplugMessage.cs
@@ -37,6 +37,20 @@ namespace ButtplugTest.Messages
         }
 
         [Fact]
+        public async void RequestLogTraceLevelTest()
+        {
+            var s = new TestService();
+            s.MessageReceived += s.OnMessageReceived;
+            ButtplugMessage[] res = await s.SendMessage("[{\"RequestLog\": {\"LogLevel\":\"Trace\",\"Id\":1}}]");
+            Assert.True(res.Length == 1);
+            Assert.True(res[0] is Ok);
+            res = await s.SendMessage("[{\"Test\": {\"TestString\":\"Echo\",\"Id\":2}}]");
+            Assert.True(res.Length == 1);
+            Assert.True(res[0] is Test);
+            Assert.True(s.outgoingAsync.Count == 3);
+        }
+
+        [Fact]
         public async void RequestNothingTest()
         {
             var s = new TestService();


### PR DESCRIPTION
This flag prevents the messages from being sent over the wire, back to the client.
Handy for cases where this might cause a log recursion or when you want to log
something that might be considered too sensitive for the client.

Issue #91