### PR TITLE
Adding the ErrorCode field to the error messages

### DIFF
--- a/Buttplug/Bluetooth/Devices/FleshlightLaunch.cs
+++ b/Buttplug/Bluetooth/Devices/FleshlightLaunch.cs
@@ -74,7 +74,7 @@ namespace Buttplug.Bluetooth.Devices
             var cmdMsg = aMsg as FleshlightLaunchFW12Cmd;
             if (cmdMsg is null)
             {
-                return BpLogger.LogErrorMsg(aMsg.Id, "Wrong Handler");
+                return BpLogger.LogErrorMsg(aMsg.Id, Error.ErrorClass.ERROR_DEVICE, "Wrong Handler");
             }
             return await Interface.WriteValue(aMsg.Id,
                 (uint)FleshlightLaunchBluetoothInfo.Chrs.Tx,

--- a/Buttplug/Bluetooth/Devices/Kiiroo.cs
+++ b/Buttplug/Bluetooth/Devices/Kiiroo.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Buttplug.Core;
 using Buttplug.Messages;
 using JetBrains.Annotations;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Bluetooth.Devices
 {
@@ -57,7 +58,7 @@ namespace Buttplug.Bluetooth.Devices
             var cmdMsg = aMsg as KiirooCmd;
             if (cmdMsg is null)
             {
-                return BpLogger.LogErrorMsg(aMsg.Id, "Wrong Handler");
+                return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE, "Wrong Handler");
             }
             return await Interface.WriteValue(cmdMsg.Id,
                 (uint)KiirooBluetoothInfo.Chrs.Tx,

--- a/Buttplug/Bluetooth/Devices/Lovense.cs
+++ b/Buttplug/Bluetooth/Devices/Lovense.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core;
 using Buttplug.Messages;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Bluetooth.Devices
 {
@@ -55,7 +56,7 @@ namespace Buttplug.Bluetooth.Devices
             var cmdMsg = aMsg as SingleMotorVibrateCmd;
             if (cmdMsg is null)
             {
-                return BpLogger.LogErrorMsg(aMsg.Id, "Wrong Handler");
+                return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE, "Wrong Handler");
             }
             return await Interface.WriteValue(aMsg.Id, 
                 (uint)LovenseBluetoothInfo.Chrs.Tx,

--- a/Buttplug/Bluetooth/Devices/VorzeA10Cyclone.cs
+++ b/Buttplug/Bluetooth/Devices/VorzeA10Cyclone.cs
@@ -3,6 +3,7 @@ using Buttplug.Messages;
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Bluetooth.Devices
 {
@@ -52,7 +53,7 @@ namespace Buttplug.Bluetooth.Devices
             var cmdMsg = aMsg as VorzeA10CycloneCmd;
             if (cmdMsg is null)
             {
-                return BpLogger.LogErrorMsg(aMsg.Id, "Wrong Handler");
+                return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE, "Wrong Handler");
             }
             byte rawSpeed = (byte)(((byte)(cmdMsg.Clockwise ? 1 : 0)) << 7 | (byte)cmdMsg.Speed);
             return await Interface.WriteValue(aMsg.Id,

--- a/Buttplug/Core/ButtplugDevice.cs
+++ b/Buttplug/Core/ButtplugDevice.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Buttplug.Messages;
 using JetBrains.Annotations;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Core
 {
@@ -43,12 +44,12 @@ namespace Buttplug.Core
         {
             if (_isDisconnected)
             {
-                return BpLogger.LogErrorMsg(aMsg.Id,
+                return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE,
                     $"{Name} has disconnected and can no longer process messages.");
             }
             if (!MsgFuncs.ContainsKey(aMsg.GetType()))
             {
-                return BpLogger.LogErrorMsg(aMsg.Id,
+                return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE,
                     $"{Name} cannot handle message of type {aMsg.GetType().Name}");
             }
             // We just checked whether the key exists above, so we're ok.

--- a/Buttplug/Core/ButtplugJSONMessageParser.cs
+++ b/Buttplug/Core/ButtplugJSONMessageParser.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using Buttplug.Messages;
 using Newtonsoft.Json.Schema;
 using System.IO;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Core
 {
@@ -109,11 +110,11 @@ namespace Buttplug.Core
                 }
                 catch (InvalidCastException e)
                 {
-                    res.Add(_bpLogger.LogErrorMsg(ButtplugConsts.SYSTEM_MSG_ID, $"Could not create message for JSON {aJsonMsg}: {e.Message}"));
+                    res.Add(_bpLogger.LogErrorMsg(ButtplugConsts.SYSTEM_MSG_ID, ErrorClass.ERROR_MSG, $"Could not create message for JSON {aJsonMsg}: {e.Message}"));
                 }
                 catch (JsonSerializationException e)
                 {
-                    res.Add(_bpLogger.LogErrorMsg(ButtplugConsts.SYSTEM_MSG_ID, $"Could not create message for JSON {aJsonMsg}: {e.Message}"));
+                    res.Add(_bpLogger.LogErrorMsg(ButtplugConsts.SYSTEM_MSG_ID, ErrorClass.ERROR_MSG, $"Could not create message for JSON {aJsonMsg}: {e.Message}"));
                 }
             }
             return res.ToArray();

--- a/Buttplug/Core/ButtplugLog.cs
+++ b/Buttplug/Core/ButtplugLog.cs
@@ -2,6 +2,7 @@
 using Buttplug.Logging;
 using Buttplug.Messages;
 using JetBrains.Annotations;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Core
 {
@@ -70,16 +71,16 @@ namespace Buttplug.Core
             }
         }
 
-        public Error LogErrorMsg(uint aId, string msg)
+        public Error LogErrorMsg(uint aId, ErrorClass code, string msg)
         {
             Error(msg, false);
-            return new Error(msg, aId);
+            return new Error(msg, code, aId);
         }
 
-        public Error LogWarnMsg(uint aId, string msg)
+        public Error LogWarnMsg(uint aId, ErrorClass code, string msg)
         {
             Warn(msg, false);
-            return new Error(msg, aId);
+            return new Error(msg, code, aId);
         }
     }
 }

--- a/Buttplug/Core/ButtplugService.cs
+++ b/Buttplug/Core/ButtplugService.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Core
 {
@@ -55,19 +56,19 @@ namespace Buttplug.Core
             var id = aMsg.Id;
             if (id == 0)
             {
-                return _bpLogger.LogWarnMsg(id,
+                return _bpLogger.LogWarnMsg(id, ErrorClass.ERROR_MSG,
                     $"Message Id 0 is reserved for outgoing system messages. Please use another Id.");
             }
             if (aMsg is IButtplugMessageOutgoingOnly)
             {
-                return _bpLogger.LogWarnMsg(id,
+                return _bpLogger.LogWarnMsg(id, ErrorClass.ERROR_MSG,
                     $"Message of type {aMsg.GetType().Name} cannot be sent to server");
             }
 
             // If we get a message that's not RequestServerInfo first, return an error.
             if (!_receivedRequestServerInfo && !(aMsg is RequestServerInfo))
             {
-                return _bpLogger.LogErrorMsg(id,
+                return _bpLogger.LogErrorMsg(id, ErrorClass.ERROR_INIT,
                     $"RequestServerInfo must be first message received by server!");
             }
             switch (aMsg)

--- a/Buttplug/Core/DeviceManager.cs
+++ b/Buttplug/Core/DeviceManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Buttplug.Messages;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Core
 {
@@ -10,6 +11,8 @@ namespace Buttplug.Core
     {
         private readonly List<IDeviceSubtypeManager> _managers;
         internal Dictionary<uint, IButtplugDevice> _devices { get; }
+        public Error.ErrorClass ERROR_DEVICE { get; private set; }
+
         private uint _deviceIndex;
         private readonly IButtplugLog _bpLogger;
         private readonly IButtplugLogManager _bpLogManager;
@@ -112,7 +115,7 @@ namespace Buttplug.Core
                     {
                         return new Ok(aMsg.Id);
                     }
-                    return new Error(errorMsg, aMsg.Id);
+                    return new Error(errorMsg, ERROR_DEVICE, aMsg.Id);
                 case RequestDeviceList _:
                     var msgDevices = _devices
                         .Select(d => new DeviceMessageInfo(d.Key, d.Value.Name,
@@ -126,9 +129,9 @@ namespace Buttplug.Core
                     {
                         return await _devices[m.DeviceIndex].ParseMessage(m);
                     }
-                    return _bpLogger.LogErrorMsg(id, $"Dropping message for unknown device index {m.DeviceIndex}");
+                    return _bpLogger.LogErrorMsg(id, ErrorClass.ERROR_DEVICE, $"Dropping message for unknown device index {m.DeviceIndex}");
             }
-            return _bpLogger.LogErrorMsg(id, $"Message type {aMsg.GetType().Name} unhandled by this server.");
+            return _bpLogger.LogErrorMsg(id, ErrorClass.ERROR_MSG, $"Message type {aMsg.GetType().Name} unhandled by this server.");
         }
 
         private void StartScanning()

--- a/Buttplug/Core/IButtplugLog.cs
+++ b/Buttplug/Core/IButtplugLog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Buttplug.Messages;
 using JetBrains.Annotations;
+using static Buttplug.Messages.Error;
 
 namespace Buttplug.Core
 {
@@ -15,8 +16,8 @@ namespace Buttplug.Core
         void Error(string aMsg, bool localOnly = false);
         void Fatal(string aMsg, bool localOnly = false);
         [NotNull]
-        Error LogErrorMsg(uint aId, string aMsg);
+        Error LogErrorMsg(uint aId, ErrorClass code, string aMsg);
         [NotNull]
-        Error LogWarnMsg(uint aId, string aMsg);
+        Error LogWarnMsg(uint aId, ErrorClass code, string aMsg);
     }
 }

--- a/Buttplug/Messages/Messages.cs
+++ b/Buttplug/Messages/Messages.cs
@@ -43,12 +43,25 @@ namespace Buttplug.Messages
 
     public class Error : ButtplugMessage, IButtplugMessageOutgoingOnly
     {
+        public enum ErrorClass
+        {
+            ERROR_UNKNOWN,
+            ERROR_INIT,
+            ERROR_PING,
+            ERROR_MSG,
+            ERROR_DEVICE
+        }
+
+        [JsonProperty(Required = Required.Always)]
+        public ErrorClass ErrorCode { get; }
+
         [JsonProperty(Required = Required.Always)]
         public string ErrorMessage { get; }
 
-        public Error(string aErrorMessage, uint aId = ButtplugConsts.SYSTEM_MSG_ID) : base(aId)
+        public Error(string aErrorMessage, ErrorClass aErrorCode, uint aId = ButtplugConsts.SYSTEM_MSG_ID) : base(aId)
         {
             ErrorMessage = aErrorMessage;
+            ErrorCode = aErrorCode;
         }
     }
 

--- a/ButtplugTest/Core/ButtplugServerTests.cs
+++ b/ButtplugTest/Core/ButtplugServerTests.cs
@@ -2,6 +2,7 @@
 using Buttplug.Messages;
 using System.Linq;
 using Xunit;
+using static Buttplug.Messages.Error;
 
 namespace ButtplugTest.Core
 {
@@ -10,7 +11,7 @@ namespace ButtplugTest.Core
         [Fact]
         public async void RejectOutgoingOnlyMessage()
         {
-            Assert.True((await new TestService().SendMessage(new Error("Error", ButtplugConsts.DEFAULT_MSG_ID))) is Error);
+            Assert.True((await new TestService().SendMessage(new Error("Error", ErrorClass.ERROR_UNKNOWN, ButtplugConsts.DEFAULT_MSG_ID))) is Error);
         }
 
         [Fact]
@@ -26,14 +27,14 @@ namespace ButtplugTest.Core
                 }
             };
             // Sending error messages will always cause an error, as they are outgoing, not incoming.
-            await s.SendMessage(new Error("Error", ButtplugConsts.DEFAULT_MSG_ID));
+            await s.SendMessage(new Error("Error", ErrorClass.ERROR_UNKNOWN, ButtplugConsts.DEFAULT_MSG_ID));
             Assert.False(gotMessage);
             Assert.True((await s.SendMessage(new RequestLog("Trace"))) is Ok);
-            Assert.True((await s.SendMessage(new Error("Error", ButtplugConsts.DEFAULT_MSG_ID))) is Error);
+            Assert.True((await s.SendMessage(new Error("Error", ErrorClass.ERROR_UNKNOWN, ButtplugConsts.DEFAULT_MSG_ID))) is Error);
             Assert.True(gotMessage);
             await s.SendMessage(new RequestLog("Off"));
             gotMessage = false;
-            await s.SendMessage(new Error("Error", ButtplugConsts.DEFAULT_MSG_ID));
+            await s.SendMessage(new Error("Error", ErrorClass.ERROR_UNKNOWN, ButtplugConsts.DEFAULT_MSG_ID));
             Assert.False(gotMessage);
         }
 

--- a/ButtplugUWPBluetoothManager/Core/UWPBluetoothDeviceInterface.cs
+++ b/ButtplugUWPBluetoothManager/Core/UWPBluetoothDeviceInterface.cs
@@ -8,6 +8,7 @@ using Buttplug.Messages;
 using Buttplug.Core;
 using Buttplug.Bluetooth;
 using JetBrains.Annotations;
+using static Buttplug.Messages.Error;
 
 namespace ButtplugUWPBluetoothManager.Core
 {
@@ -62,14 +63,14 @@ namespace ButtplugUWPBluetoothManager.Core
             var gattCharacteristic = _gattCharacteristics[aCharacteristicIndex];
             if (gattCharacteristic == null)
             {
-                return _bpLogger.LogErrorMsg(aMsgId, $"Requested character {aCharacteristicIndex} out of range");
+                return _bpLogger.LogErrorMsg(aMsgId, ErrorClass.ERROR_DEVICE, $"Requested character {aCharacteristicIndex} out of range");
             }
             _currentTask = gattCharacteristic.WriteValueAsync(aValue.AsBuffer());
             var status = await _currentTask;
             _currentTask = null;
             if (status != GattCommunicationStatus.Success)
             {
-                return _bpLogger.LogErrorMsg(aMsgId, $"GattCommunication Error: {status}");
+                return _bpLogger.LogErrorMsg(aMsgId, ErrorClass.ERROR_DEVICE, $"GattCommunication Error: {status}");
             }
             return new Ok(aMsgId);
         }
@@ -84,14 +85,14 @@ namespace ButtplugUWPBluetoothManager.Core
         public Task<ButtplugMessage> Subscribe(uint aMsgId,
             uint aCharacertisticIndex)
         {
-            return Task.FromResult<ButtplugMessage>(_bpLogger.LogErrorMsg(aMsgId, "Not implemented."));
+            return Task.FromResult<ButtplugMessage>(_bpLogger.LogErrorMsg(aMsgId, ErrorClass.ERROR_UNKNOWN, "Not implemented."));
         }
 
         [ItemNotNull]
         public Task<ButtplugMessage> Unsubscribe(uint aMsgId,
             uint aCharacertisticIndex)
         {
-            return Task.FromResult<ButtplugMessage>(_bpLogger.LogErrorMsg(aMsgId, "Not implemented."));
+            return Task.FromResult<ButtplugMessage>(_bpLogger.LogErrorMsg(aMsgId, ErrorClass.ERROR_UNKNOWN, "Not implemented."));
         }
     }
 }

--- a/ButtplugUWPGamepadManager/Devices/UWPGamepadDevice.cs
+++ b/ButtplugUWPGamepadManager/Devices/UWPGamepadDevice.cs
@@ -2,6 +2,7 @@
 using Windows.Gaming.Input;
 using Buttplug.Core;
 using Buttplug.Messages;
+using static Buttplug.Messages.Error;
 
 namespace ButtplugUWPGamepadManager.Devices
 {
@@ -24,7 +25,7 @@ namespace ButtplugUWPGamepadManager.Devices
             var cmdMsg = aMsg as SingleMotorVibrateCmd;
             if (cmdMsg is null)
             {
-                return BpLogger.LogErrorMsg(aMsg.Id, "Wrong Handler");
+                return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE, "Wrong Handler");
             }
             var v = new GamepadVibration()
             {

--- a/ButtplugXInputGamepadManager/Devices/XInputGamepadDevice.cs
+++ b/ButtplugXInputGamepadManager/Devices/XInputGamepadDevice.cs
@@ -2,6 +2,7 @@
 using Buttplug.Core;
 using Buttplug.Messages;
 using SharpDX.XInput;
+using static Buttplug.Messages.Error;
 
 namespace ButtplugXInputGamepadManager.Devices
 {
@@ -27,7 +28,7 @@ namespace ButtplugXInputGamepadManager.Devices
             var cmdMsg = aMsg as SingleMotorVibrateCmd;
             if (cmdMsg is null)
             {
-                return Task.FromResult<ButtplugMessage>(BpLogger.LogErrorMsg(aMsg.Id, "Wrong Handler"));
+                return Task.FromResult<ButtplugMessage>(BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE, "Wrong Handler"));
             }
             var v = new Vibration()
             {


### PR DESCRIPTION
The aviable values of ErrorCode are contained in the  Error.ErrorClass enum. All existing uses have been updated to send the appropriate codes.

Issue #96