### PR TITLE
feat: Add Lovense Edge support, break Lovense Info into revisions

### DIFF
--- a/Buttplug/Bluetooth/BluetoothSubtypeManager.cs
+++ b/Buttplug/Bluetooth/BluetoothSubtypeManager.cs
@@ -20,7 +20,9 @@ namespace Buttplug.Bluetooth
             {
                 new FleshlightLaunchBluetoothInfo(),
                 new KiirooBluetoothInfo(),
-                new LovenseBluetoothInfo(),
+                new LovenseRev1BluetoothInfo(),
+                new LovenseRev2BluetoothInfo(),
+                new LovenseRev3BluetoothInfo(),
                 new VorzeA10CycloneInfo()
             };
         }

--- a/Buttplug/Bluetooth/Devices/Lovense.cs
+++ b/Buttplug/Bluetooth/Devices/Lovense.cs
@@ -7,7 +7,40 @@ using static Buttplug.Messages.Error;
 
 namespace Buttplug.Bluetooth.Devices
 {
-    internal class LovenseBluetoothInfo : IBluetoothDeviceInfo
+    internal class LovenseRev1BluetoothInfo : IBluetoothDeviceInfo
+    {
+        public enum Chrs : uint
+        {
+            Tx = 0,
+            Rx
+        }
+
+        public Guid[] Services { get; } = { new Guid("0000fff0-0000-1000-8000-00805f9b34fb") };
+        public string[] Names { get; } = 
+        {
+            // Nora
+            "LVS-A011", "LVS-C011",
+            // Max
+            "LVS-B011" };
+
+        public Guid[] Characteristics { get; } =
+        {
+            // tx characteristic
+            new Guid("0000fff2-0000-1000-8000-00805f9b34fb")//,
+            // rx characteristic
+            // Comment out until issue #108 is fixed. Characteristic isn't really needed until Issue #9 is implemented also.
+            //new Guid("0000fff1-0000-1000-8000-00805f9b34fb")
+        };
+
+        public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
+            IBluetoothDeviceInterface aInterface)
+        {
+            return new Lovense(aLogManager,
+                aInterface);
+        }
+    }
+
+    internal class LovenseRev2BluetoothInfo : IBluetoothDeviceInfo
     {
         public enum Chrs : uint
         {
@@ -16,7 +49,13 @@ namespace Buttplug.Bluetooth.Devices
         }
 
         public Guid[] Services { get; } = { new Guid("6e400001-b5a3-f393-e0a9-e50e24dcca9e") };
-        public string[] Names { get; } = { "LVS-S001", "LVS-Z001" };
+        public string[] Names { get; } =
+        {
+            // Lush
+            "LVS-S001",
+            // Hush
+            "LVS-Z001"
+        };
 
         public Guid[] Characteristics { get; } =
         {
@@ -31,6 +70,37 @@ namespace Buttplug.Bluetooth.Devices
         {
             return new Lovense(aLogManager,
                                aInterface);
+        }
+    }
+
+    internal class LovenseRev3BluetoothInfo : IBluetoothDeviceInfo
+    {
+        public enum Chrs : uint
+        {
+            Tx = 0,
+            Rx
+        }
+
+        public Guid[] Services { get; } = { new Guid("50300001-0024-4bd4-bbd5-a6920e4c5653") };
+        public string[] Names { get; } =
+        {
+            // Edge
+            "LVS-P36"
+        };
+
+        public Guid[] Characteristics { get; } =
+        {
+            // tx characteristic
+            new Guid("50300002-0024-4bd4-bbd5-a6920e4c5653"),
+            // rx characteristic
+            new Guid("50300003-0024-4bd4-bbd5-a6920e4c5653")
+        };
+
+        public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
+            IBluetoothDeviceInterface aInterface)
+        {
+            return new Lovense(aLogManager,
+                aInterface);
         }
     }
 
@@ -59,7 +129,8 @@ namespace Buttplug.Bluetooth.Devices
                 return BpLogger.LogErrorMsg(aMsg.Id, ErrorClass.ERROR_DEVICE, "Wrong Handler");
             }
             return await Interface.WriteValue(aMsg.Id, 
-                (uint)LovenseBluetoothInfo.Chrs.Tx,
+                // While there are 3 lovense revs right now, all of the characteristic arrays are the same.
+                (uint)LovenseRev1BluetoothInfo.Chrs.Tx,
                 Encoding.ASCII.GetBytes($"Vibrate:{(int)(cmdMsg.Speed * 20)};"));
         }
     }


### PR DESCRIPTION
The Lovense Edge uses the same commands as the other lovense
revisions, but requires new service/characteristics UUID and a name.
To support all 3 revisions of Lovense hardware, 2 IBluetoothDeviceInfo
classes are added. This should hopefully let us support everything we
have device names for at the moment. Only released toy we don't
support is the Ambi, which we need a device name for.

Fixes #105