### PR TITLE
Tweaking the websocketserver usage

### DIFF
--- a/ButtplugWebsockets/ButtplugWebsocketServer.cs
+++ b/ButtplugWebsockets/ButtplugWebsocketServer.cs
@@ -14,13 +14,13 @@ namespace ButtplugWebsockets
 
         public ButtplugWebsocketServer()
         {
-            _wsServer = new WebSocketServer("ws://localhost:12345");
+            _wsServer = new WebSocketServer(12345);
             _wsServer.RemoveWebSocketService("/buttplug");
         }
 
         public void StartServer([NotNull] ButtplugService aService)
         {
-            _wsServer.AddWebSocketService<ButtplugWebsocketServerBehavior>("/buttplug", () => new ButtplugWebsocketServerBehavior(aService));
+            _wsServer.WebSocketServices.AddService<ButtplugWebsocketServerBehavior>("/buttplug", (obj) => obj.Service = aService );
             _wsServer.Start();
         }
 

--- a/ButtplugWebsockets/ButtplugWebsocketServerBehavior.cs
+++ b/ButtplugWebsockets/ButtplugWebsocketServerBehavior.cs
@@ -13,23 +13,24 @@ namespace ButtplugWebsockets
 {
     public class ButtplugWebsocketServerBehavior : WebSocketBehavior
     {
-        [NotNull]
-        private readonly ButtplugService _buttplug;
-
-        public ButtplugWebsocketServerBehavior()
-            : this(null)
+        private ButtplugService _buttplug;
+        
+        public ButtplugService Service
         {
-            
+            set {
+                if (_buttplug != null)
+                {
+                    throw new AccessViolationException("Service already set!");
+                }
+                _buttplug = value;
+                _buttplug.MessageReceived += OnMessageReceived;
+            }
+            private get { return _buttplug; }
         }
 
-        public ButtplugWebsocketServerBehavior(ButtplugService aService)
+        public ButtplugWebsocketServerBehavior()
         {
-            if (aService == null)
-            {
-                return;
-            }
-            _buttplug = aService;
-            _buttplug.MessageReceived += OnMessageReceived;
+
         }
 
         protected override async void OnClose(CloseEventArgs e)


### PR DESCRIPTION
This change removes the use of the deprecated AddWebSocketService, using AddService instead.
The server is also configured to listen on just a port now, meaning it should trigger the Windows Firewall to prompt to ask on which networks it should be allowed to start listening on.