### PR TITLE
feat: Add ping message handling to ButtplugService

### DIFF
--- a/Buttplug/Core/ButtplugService.cs
+++ b/Buttplug/Core/ButtplugService.cs
@@ -77,6 +77,9 @@ namespace Buttplug.Core
                     _bpLogManager.Level = m.LogLevel;
                     return new Ok(id);
 
+                case Ping m:
+                    return new Ok(id);
+
                 case RequestServerInfo _:
                     _receivedRequestServerInfo = true;
                     return new ServerInfo(_serverName, 1, _maxPingTime, id);


### PR DESCRIPTION
Just returns an Ok, so that clients that want to implement ping now
will be ready when we have the actual rules in.

Affects #81