### PR TITLE
Switching over to HTTPS , with a HTML landing page

### DIFF
--- a/ButtplugServerGUI/ButtplugConfig.cs
+++ b/ButtplugServerGUI/ButtplugConfig.cs
@@ -1,0 +1,89 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButtplugServerGUI
+{
+    public class ButtplugConfig
+    {
+        private readonly string configFile;
+        private JObject config;
+        private DateTime modtime;
+
+        public ButtplugConfig(string app)
+        {
+            configFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), app, "config.json");
+
+            config = new JObject();
+            modtime = DateTime.MinValue;
+            LoadConfig();
+        }
+
+        private void LoadConfig()
+        {
+            if(File.Exists(configFile) && File.GetLastWriteTimeUtc(configFile) > modtime)
+            {
+                try
+                {
+                    config = JObject.Parse(File.ReadAllText(configFile));
+                    modtime = File.GetLastWriteTimeUtc(configFile);
+                }
+                catch
+                {
+
+                }
+            }
+        }
+
+        private void SaveConfig()
+        {
+            try
+            {
+                File.WriteAllText(configFile, config.ToString());
+                modtime = File.GetLastWriteTimeUtc(configFile);
+            }
+            catch
+            {
+
+            }
+        }
+
+        public string GetValue(string key, string other = null)
+        {
+            var bits = key.Split('.');
+            LoadConfig();
+            JToken cfg = config;
+            for(int i = 0; cfg != null && i < bits.Length; i++)
+            {
+                cfg = cfg[bits[i]];
+            }
+            if(cfg != null)
+            {
+                return cfg.Value<string>();
+            }
+            return other;
+        }
+
+        public void SetValue(string key, string value)
+        {
+            var bits = key.Split('.');
+            LoadConfig();
+            JToken cfg = config;
+            for (int i = 0; cfg != null && i < bits.Length-1; i++)
+            {
+                if(cfg[bits[i]] == null)
+                {
+                    cfg[bits[i]] = new JObject();
+                }
+                cfg = cfg[bits[i]];
+            }
+            
+            cfg[bits[bits.Length-1]] = value;
+            SaveConfig();
+        }
+    }
+}

--- a/ButtplugServerGUI/ButtplugServerGUI.csproj
+++ b/ButtplugServerGUI/ButtplugServerGUI.csproj
@@ -37,6 +37,9 @@
     <ApplicationIcon>Resources\buttplug-icon-1.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -57,6 +60,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="ButtplugConfig.cs" />
     <Compile Include="WebsocketServerControl.xaml.cs">
       <DependentUpon>WebsocketServerControl.xaml</DependentUpon>
     </Compile>
@@ -95,6 +99,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/ButtplugServerGUI/MainWindow.xaml.cs
+++ b/ButtplugServerGUI/MainWindow.xaml.cs
@@ -24,9 +24,9 @@ namespace ButtplugServerGUI
         {
             InitializeComponent();
             ButtplugTab.InitializeButtplugServer("Websocket Server", 100).Wait();
-            var wsTab = new WebsocketServerControl();
+            var wsTab = new WebsocketServerControl(ButtplugTab.BpServer);
             ButtplugTab.SetApplicationTab("Websocket Server", wsTab);
-            wsTab.StartServer(ButtplugTab.BpServer);
+            wsTab.StartServer();
         }
     }
 }

--- a/ButtplugServerGUI/WebsocketServerControl.xaml
+++ b/ButtplugServerGUI/WebsocketServerControl.xaml
@@ -6,7 +6,11 @@
              xmlns:local="clr-namespace:ButtplugServerGUI"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-            
-    </Grid>
+	<Grid>
+		<CheckBox Name="SecureCheckBox" Content="SSL/TLS" HorizontalAlignment="Left" Margin="229,17,0,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
+		<TextBox Name="PortTextBox" HorizontalAlignment="Left" Height="23" Margin="55,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" TextChanged="PortTextBox_TextChanged"/>
+		<Label Content="Port:" HorizontalAlignment="Right" Margin="0,10,256,0" VerticalAlignment="Top"/>
+		<Button Name="ConnToggleButton" Content="Start" HorizontalAlignment="Left" Margin="216,45,0,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
+
+	</Grid>
 </UserControl>

--- a/ButtplugServerGUI/WebsocketServerControl.xaml
+++ b/ButtplugServerGUI/WebsocketServerControl.xaml
@@ -5,12 +5,17 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:ButtplugServerGUI"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
-	<Grid>
-		<CheckBox Name="SecureCheckBox" Content="SSL/TLS" HorizontalAlignment="Left" Margin="229,17,0,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
-		<TextBox Name="PortTextBox" HorizontalAlignment="Left" Height="23" Margin="55,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" TextChanged="PortTextBox_TextChanged"/>
-		<Label Content="Port:" HorizontalAlignment="Right" Margin="0,10,256,0" VerticalAlignment="Top"/>
-		<Button Name="ConnToggleButton" Content="Start" HorizontalAlignment="Left" Margin="216,45,0,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
+            d:DesignHeight="300" d:DesignWidth="525">
+	<Grid Background="#FFE5E5E5" >
+		<Grid.RowDefinitions>
+			<RowDefinition Height="45"/>
+			<RowDefinition Height="25"/>
+		</Grid.RowDefinitions>
+		<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
+		<TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" TextChanged="PortTextBox_TextChanged"/>
+		<CheckBox Name="SecureCheckBox"  Grid.Row="0" Content="SSL/TLS" HorizontalAlignment="Right" Margin="0,17,10,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
+		
+		<Button Name="ConnToggleButton"  Grid.Row="1" Content="Start" HorizontalAlignment="Right" Margin="0,0,10,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
 
 	</Grid>
 </UserControl>

--- a/ButtplugServerGUI/WebsocketServerControl.xaml.cs
+++ b/ButtplugServerGUI/WebsocketServerControl.xaml.cs
@@ -1,19 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Buttplug.Core;
 using ButtplugWebsockets;
+using Buttplug.Core;
 
 namespace ButtplugServerGUI
 {
@@ -26,14 +15,26 @@ namespace ButtplugServerGUI
         private ButtplugService _service;
         private uint _port;
         private bool _secure;
+        private ButtplugConfig _config;
 
         public WebsocketServerControl(ButtplugService aService)
         {
             InitializeComponent();
             _ws = new ButtplugWebsocketServer();
+            _config = new ButtplugConfig("Buttplug");
             _service = aService;
             _port = 12345;
             _secure = false;
+            if (UInt32.TryParse(_config.GetValue("buttplug.server.port", "12345"), out uint pres))
+            {
+                _port = pres;
+            }
+            if (Boolean.TryParse(_config.GetValue("buttplug.server.secure", "false"), out bool sres))
+            {
+                _secure = sres;
+            }
+            ((TextBox)PortTextBox).Text = _port.ToString();
+            ((CheckBox)SecureCheckBox).IsChecked = _secure;
         }
 
         public void StartServer()
@@ -53,10 +54,11 @@ namespace ButtplugServerGUI
 
         private void ConnToggleButton_Click(object sender, RoutedEventArgs e)
         {
-
-            if (((Button)ConnToggleButton).Content == "Start")
+            if (((Button)ConnToggleButton).Content.Equals("Start"))
             {
                 StartServer();
+                _config.SetValue("buttplug.server.port", _port.ToString());
+                _config.SetValue("buttplug.server.secure", _secure.ToString());
             }
             else
             {

--- a/ButtplugServerGUI/WebsocketServerControl.xaml.cs
+++ b/ButtplugServerGUI/WebsocketServerControl.xaml.cs
@@ -23,17 +23,66 @@ namespace ButtplugServerGUI
     public partial class WebsocketServerControl : UserControl
     {
         private ButtplugWebsocketServer _ws;
+        private ButtplugService _service;
+        private uint _port;
+        private bool _secure;
 
-        public WebsocketServerControl()
+        public WebsocketServerControl(ButtplugService aService)
         {
             InitializeComponent();
             _ws = new ButtplugWebsocketServer();
-            
+            _service = aService;
+            _port = 12345;
+            _secure = false;
         }
 
-        public void StartServer(ButtplugService aService)
+        public void StartServer()
         {
-            _ws.StartServer(aService);
+            _ws.StartServer(_service, (int) _port, _secure);
+            ((Button)ConnToggleButton).Content = "Stop";
+            ((CheckBox)SecureCheckBox).IsEnabled = false;
+            ((TextBox)PortTextBox).IsEnabled = false;
+        }
+        public void StopServer()
+        {
+            _ws.StopServer();
+            ((Button)ConnToggleButton).Content = "Start";
+            ((CheckBox)SecureCheckBox).IsEnabled = true;
+            ((TextBox)PortTextBox).IsEnabled = true;
+        }
+
+        private void ConnToggleButton_Click(object sender, RoutedEventArgs e)
+        {
+
+            if (((Button)ConnToggleButton).Content == "Start")
+            {
+                StartServer();
+            }
+            else
+            {
+                StopServer();
+            }
+        }
+       
+
+        private void PortTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (UInt32.TryParse(((TextBox)PortTextBox).Text, out uint port) && port >= 1024 && port <= 65535)
+            {
+                _port = port;
+                return;
+            }
+            ((TextBox)PortTextBox).Text = _port.ToString();
+        }
+
+        private void SecureCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            _secure = false;
+        }
+
+        private void SecureCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            _secure = true;
         }
     }
 }

--- a/ButtplugServerGUI/packages.config
+++ b/ButtplugServerGUI/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+</packages>

--- a/ButtplugWebsockets/ButtplugWebsocketServer.cs
+++ b/ButtplugWebsockets/ButtplugWebsocketServer.cs
@@ -16,9 +16,10 @@ namespace ButtplugWebsockets
 
         public ButtplugWebsocketServer()
         {
-            _wsServer = new HttpServer(12345);
+            _wsServer = new HttpServer(12345, true);
             _wsServer.RemoveWebSocketService("/buttplug");
             _wsServer.OnGet += OnGetHandler;
+            _wsServer.SslConfiguration.ServerCertificate = CertUtils.GetCert("Buttplug");
         }
 
         public void StartServer([NotNull] ButtplugService aService)

--- a/ButtplugWebsockets/ButtplugWebsocketServer.cs
+++ b/ButtplugWebsockets/ButtplugWebsocketServer.cs
@@ -4,30 +4,57 @@ using Buttplug.Core;
 using JetBrains.Annotations;
 using WebSocketSharp;
 using WebSocketSharp.Server;
+using WebSocketSharp.Net;
+using System.Security.Cryptography.X509Certificates;
 
 namespace ButtplugWebsockets
 {
     public class ButtplugWebsocketServer
     {
         [NotNull]
-        private WebSocketServer _wsServer;
+        private HttpServer _wsServer;
 
         public ButtplugWebsocketServer()
         {
-            _wsServer = new WebSocketServer(12345);
+            _wsServer = new HttpServer(12345);
             _wsServer.RemoveWebSocketService("/buttplug");
+            _wsServer.OnGet += OnGetHandler;
         }
 
         public void StartServer([NotNull] ButtplugService aService)
         {
-            _wsServer.WebSocketServices.AddService<ButtplugWebsocketServerBehavior>("/buttplug", (obj) => obj.Service = aService );
+            _wsServer.WebSocketServices.AddService<ButtplugWebsocketServerBehavior>("/buttplug", (obj) => obj.Service = aService);
             _wsServer.Start();
         }
 
         public void StopServer()
         {
             _wsServer.Stop();
-            _wsServer.RemoveWebSocketService("/buttplug");            
+            _wsServer.RemoveWebSocketService("/buttplug");
+        }
+
+        protected void OnGetHandler(object sender, HttpRequestEventArgs e)
+        {
+            var req = e.Request;
+            var res = e.Response;
+
+            // Wouldn't it be cool to present syncydink here?
+
+            var path = req.RawUrl;
+            if (path == "/")
+                path += "index.html";
+
+            if (path != "/index.html")
+            {
+                res.StatusCode = (int)HttpStatusCode.TemporaryRedirect;
+                res.RedirectLocation = "/index.html";
+                return;
+            }
+
+            res.ContentType = "text/html";
+            res.ContentEncoding = Encoding.UTF8;
+            res.WriteContent(Encoding.UTF8.GetBytes("<html><head><title>Buttplug server</title></head><body><h1>Buttplug server</h1><p>The server is running.</p></body></html>"));
+
         }
     }
 

--- a/ButtplugWebsockets/ButtplugWebsocketServer.cs
+++ b/ButtplugWebsockets/ButtplugWebsocketServer.cs
@@ -11,19 +11,21 @@ namespace ButtplugWebsockets
 {
     public class ButtplugWebsocketServer
     {
-        [NotNull]
         private HttpServer _wsServer;
 
         public ButtplugWebsocketServer()
         {
-            _wsServer = new HttpServer(12345, true);
-            _wsServer.RemoveWebSocketService("/buttplug");
-            _wsServer.OnGet += OnGetHandler;
-            _wsServer.SslConfiguration.ServerCertificate = CertUtils.GetCert("Buttplug");
         }
 
-        public void StartServer([NotNull] ButtplugService aService)
+        public void StartServer([NotNull] ButtplugService aService, int port = 12345, bool secure = false)
         {
+            _wsServer = new HttpServer(port, secure);
+            _wsServer.RemoveWebSocketService("/buttplug");
+            _wsServer.OnGet += OnGetHandler;
+            if (secure)
+            {
+                _wsServer.SslConfiguration.ServerCertificate = CertUtils.GetCert("Buttplug");
+            }
             _wsServer.WebSocketServices.AddService<ButtplugWebsocketServerBehavior>("/buttplug", (obj) => obj.Service = aService);
             _wsServer.Start();
         }
@@ -32,6 +34,7 @@ namespace ButtplugWebsockets
         {
             _wsServer.Stop();
             _wsServer.RemoveWebSocketService("/buttplug");
+            _wsServer = null;
         }
 
         protected void OnGetHandler(object sender, HttpRequestEventArgs e)

--- a/ButtplugWebsockets/ButtplugWebsockets.csproj
+++ b/ButtplugWebsockets/ButtplugWebsockets.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <HintPath>..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+    </Reference>
     <Reference Include="JetBrains.Annotations, Version=10.4.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.10.4.0\lib\net\JetBrains.Annotations.dll</HintPath>
     </Reference>
@@ -39,6 +42,7 @@
   <ItemGroup>
     <Compile Include="ButtplugWebsocketServer.cs" />
     <Compile Include="ButtplugWebsocketServerBehavior.cs" />
+    <Compile Include="CertUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -53,7 +57,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ButtplugWebsockets/CertUtils.cs
+++ b/ButtplugWebsockets/CertUtils.cs
@@ -1,0 +1,160 @@
+﻿using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Pkcs;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Utilities;
+using Org.BouncyCastle.X509;
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+namespace ButtplugWebsockets
+{
+    class CertUtils
+    {
+        // Note: Much of this code comes from https://stackoverflow.com/a/22247129
+        public static X509Certificate2 GenerateSelfSignedCertificate(string subjectName, string issuerName, AsymmetricKeyParameter issuerPrivKey)
+        {
+            const int keyStrength = 2048;
+            // Generating Random Numbers
+            CryptoApiRandomGenerator randomGenerator = new CryptoApiRandomGenerator();
+            SecureRandom random = new SecureRandom(randomGenerator);
+            // The Certificate Generator
+            X509V3CertificateGenerator certificateGenerator = new X509V3CertificateGenerator();
+            // Serial Number
+            BigInteger serialNumber = BigIntegers.CreateRandomInRange(BigInteger.One, BigInteger.ValueOf(Int64.MaxValue), random);
+            certificateGenerator.SetSerialNumber(serialNumber);
+            // Signature Algorithm
+            const string signatureAlgorithm = "SHA256WithRSA";
+            certificateGenerator.SetSignatureAlgorithm(signatureAlgorithm);
+            // Issuer and Subject Name
+            X509Name subjectDN = new X509Name(subjectName);
+            X509Name issuerDN = new X509Name(issuerName);
+            certificateGenerator.SetIssuerDN(issuerDN);
+            certificateGenerator.SetSubjectDN(subjectDN);
+            // Valid For
+            DateTime notBefore = DateTime.UtcNow.Date;
+            DateTime notAfter = notBefore.AddYears(2);
+            certificateGenerator.SetNotBefore(notBefore);
+            certificateGenerator.SetNotAfter(notAfter);
+            // Subject Public Key
+            AsymmetricCipherKeyPair subjectKeyPair;
+            var keyGenerationParameters = new KeyGenerationParameters(random, keyStrength);
+            var keyPairGenerator = new RsaKeyPairGenerator();
+            keyPairGenerator.Init(keyGenerationParameters);
+            subjectKeyPair = keyPairGenerator.GenerateKeyPair();
+            certificateGenerator.SetPublicKey(subjectKeyPair.Public);
+            // Generating the Certificate
+            AsymmetricCipherKeyPair issuerKeyPair = subjectKeyPair;
+            // selfsign certificate
+            Org.BouncyCastle.X509.X509Certificate certificate = certificateGenerator.Generate(issuerPrivKey, random);
+            // correcponding private key
+            PrivateKeyInfo info = PrivateKeyInfoFactory.CreatePrivateKeyInfo(subjectKeyPair.Private);
+            // merge into X509Certificate2
+            X509Certificate2 x509 = new System.Security.Cryptography.X509Certificates.X509Certificate2(certificate.GetEncoded());
+            Asn1Sequence seq = (Asn1Sequence)Asn1Object.FromByteArray(info.PrivateKey.GetDerEncoded());
+            if (seq.Count != 9)
+            {
+                //throw new PemException("malformed sequence in RSA private key");
+            }
+            RsaPrivateKeyStructure rsa = new RsaPrivateKeyStructure(seq);
+            RsaPrivateCrtKeyParameters rsaparams = new RsaPrivateCrtKeyParameters(
+                rsa.Modulus, rsa.PublicExponent, rsa.PrivateExponent, rsa.Prime1, rsa.Prime2, rsa.Exponent1, rsa.Exponent2, rsa.Coefficient);
+            x509.PrivateKey = ToDotNetKey(rsaparams); //x509.PrivateKey = DotNetUtilities.ToRSA(rsaparams);
+            return x509;
+        }
+        public static AsymmetricAlgorithm ToDotNetKey(RsaPrivateCrtKeyParameters privateKey)
+        {
+            var cspParams = new CspParameters
+            {
+                KeyContainerName = Guid.NewGuid().ToString(),
+                KeyNumber = (int)KeyNumber.Exchange,
+                Flags = CspProviderFlags.UseMachineKeyStore
+            };
+            var rsaProvider = new RSACryptoServiceProvider(cspParams);
+            var parameters = new RSAParameters
+            {
+                Modulus = privateKey.Modulus.ToByteArrayUnsigned(),
+                P = privateKey.P.ToByteArrayUnsigned(),
+                Q = privateKey.Q.ToByteArrayUnsigned(),
+                DP = privateKey.DP.ToByteArrayUnsigned(),
+                DQ = privateKey.DQ.ToByteArrayUnsigned(),
+                InverseQ = privateKey.QInv.ToByteArrayUnsigned(),
+                D = privateKey.Exponent.ToByteArrayUnsigned(),
+                Exponent = privateKey.PublicExponent.ToByteArrayUnsigned()
+            };
+            rsaProvider.ImportParameters(parameters);
+            return rsaProvider;
+        }
+        public static X509Certificate2 GenerateCACertificate(string subjectName, ref AsymmetricKeyParameter CaPrivateKey)
+        {
+            const int keyStrength = 2048;
+            // Generating Random Numbers
+            CryptoApiRandomGenerator randomGenerator = new CryptoApiRandomGenerator();
+            SecureRandom random = new SecureRandom(randomGenerator);
+            // The Certificate Generator
+            X509V3CertificateGenerator certificateGenerator = new X509V3CertificateGenerator();
+            // Serial Number
+            BigInteger serialNumber = BigIntegers.CreateRandomInRange(BigInteger.One, BigInteger.ValueOf(Int64.MaxValue), random);
+            certificateGenerator.SetSerialNumber(serialNumber);
+            // Signature Algorithm
+            const string signatureAlgorithm = "SHA256WithRSA";
+            certificateGenerator.SetSignatureAlgorithm(signatureAlgorithm);
+            // Issuer and Subject Name
+            X509Name subjectDN = new X509Name(subjectName);
+            X509Name issuerDN = subjectDN;
+            certificateGenerator.SetIssuerDN(issuerDN);
+            certificateGenerator.SetSubjectDN(subjectDN);
+            // Valid For
+            DateTime notBefore = DateTime.UtcNow.Date;
+            DateTime notAfter = notBefore.AddYears(2);
+            certificateGenerator.SetNotBefore(notBefore);
+            certificateGenerator.SetNotAfter(notAfter);
+            // Subject Public Key
+            AsymmetricCipherKeyPair subjectKeyPair;
+            KeyGenerationParameters keyGenerationParameters = new KeyGenerationParameters(random, keyStrength);
+            RsaKeyPairGenerator keyPairGenerator = new RsaKeyPairGenerator();
+            keyPairGenerator.Init(keyGenerationParameters);
+            subjectKeyPair = keyPairGenerator.GenerateKeyPair();
+            certificateGenerator.SetPublicKey(subjectKeyPair.Public);
+            // Generating the Certificate
+            AsymmetricCipherKeyPair issuerKeyPair = subjectKeyPair;
+            // selfsign certificate
+            Org.BouncyCastle.X509.X509Certificate certificate = certificateGenerator.Generate(issuerKeyPair.Private, random);
+            X509Certificate2 x509 = new System.Security.Cryptography.X509Certificates.X509Certificate2(certificate.GetEncoded());
+            CaPrivateKey = issuerKeyPair.Private;
+            return x509;
+            //return issuerKeyPair.Private;
+        }
+        public static X509Certificate2 GetCert(string app)
+        {
+            var appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), app);
+            var caPfx = Path.Combine(appPath, "ca.pfx");
+            var certPfx = Path.Combine(appPath, "cert.pfx");
+            if (!File.Exists(caPfx) || !File.Exists(certPfx))
+            {
+                AsymmetricKeyParameter caPrivateKey = null;
+                var caCert = GenerateCACertificate("CN=" + app + "CA", ref caPrivateKey);
+                var clientCert = GenerateSelfSignedCertificate("CN=127.0.0.1", "CN=" + app + "CA", caPrivateKey);
+                var p12ca = new X509Certificate2(caCert.Export(X509ContentType.Pfx), (string)null).Export(X509ContentType.Pfx);
+                var p12cert = clientCert.Export(X509ContentType.Pfx);
+                Directory.CreateDirectory(appPath);
+                var w = File.OpenWrite(caPfx);
+                w.Write(p12ca, 0, p12ca.Length);
+                w.Close();
+                w = File.OpenWrite(certPfx);
+                w.Write(p12cert, 0, p12cert.Length);
+                w.Close();
+            }
+            return new X509Certificate2(File.ReadAllBytes(certPfx), (string)null, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+        }
+    }
+}

--- a/ButtplugWebsockets/packages.config
+++ b/ButtplugWebsockets/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.1" targetFramework="net452" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net452" />
 </packages>

--- a/LICENSE
+++ b/LICENSE
@@ -273,15 +273,55 @@ limitations under the License.
 
 --
 
-NJsonSchema (https://github.com/RSuter/NJsonSchema) is covered under
-the following MIT License:
+NJsonSchema (https://github.com/RSuter/NJsonSchema) is covered under the
+following MIT License:
 
 The MIT License (MIT)
 
 Copyright (c) 2016 Rico Suter
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--
+
+BouncyCastle (http://www.bouncycastle.org) is covered under the following
+adapted MIT X11 License:
+
+LICENSE
+
+Copyright (c) 2000 - 2017 The Legion of the Bouncy Castle Inc.
+(http://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. 


### PR DESCRIPTION
Now you can use the WebSocket from JS hosted on a page severed over HTTPS (point the client at wss://127.0.0.1/buttplug)

This change adds cert generation (a self signed CA and a child cert) and stores them in %appdata%\Buttplug. The existing cert is loaded into the WebSocketServer if one already exists.

The GUI has been updated to you can now specify the port Buttplug will listen on and whether it will use SSL or not. This configuration is persisted to %appdata%\Buttplug\config.json.

I think we need still need add some interface to make it easy to get the CA cert installed into the browser, but right now point your browser at the server will work: the web socket server has been swapped to the HttpServer variant, which gives us a test page we can point browsers to to test SSL issues etc.
Point your browser at https://127.0.0.1:12345/index.html

In the future, it'd be cool to present syncydink here, so that users can test with just a browser (no additional media required).