### PR TITLE
Adding a License Information diaglog off of the About tab

### DIFF
--- a/Buttplug/Buttplug.csproj
+++ b/Buttplug/Buttplug.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <EmbeddedResource Include="..\dependencies\buttplug-schema\schema\buttplug-schema.json" />
+    <EmbeddedResource Include="..\LICENSE" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Buttplug/Core/ButtplugService.cs
+++ b/Buttplug/Core/ButtplugService.cs
@@ -2,6 +2,8 @@
 using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using static Buttplug.Messages.Error;
 
@@ -24,6 +26,17 @@ namespace Buttplug.Core
         private uint _maxPingTime;
         private readonly uint _messageSchemaVersion;
         private bool _receivedRequestServerInfo;
+
+        public static string GetLicense()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var resourceName = "Buttplug.LICENSE";
+            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+        }
 
         public ButtplugService(string aServerName, uint aMaxPingTime)
         {

--- a/ButtplugControlLibrary/ButtplugAboutControl.xaml
+++ b/ButtplugControlLibrary/ButtplugAboutControl.xaml
@@ -16,6 +16,7 @@
                 Software updates at <Hyperlink NavigateUri="https://github.com/metafetish" RequestNavigate="Hyperlink_RequestNavigate">https://buttplug.io/</Hyperlink><LineBreak/>
                 Documentation at <Hyperlink NavigateUri="https://buttplug.io/docs" RequestNavigate="Hyperlink_RequestNavigate">https://buttplug.io/docs</Hyperlink><LineBreak/>
                 Source code at <Hyperlink NavigateUri="https://github.com/metafetish" RequestNavigate="Hyperlink_RequestNavigate">https://github.com/metafetish</Hyperlink><LineBreak/>
+                License information <Hyperlink Click="LicenseHyperlink_Click" >here</Hyperlink><LineBreak/>
             </TextBlock>
             <TextBlock HorizontalAlignment="Left" Margin="7,147,0,0" TextWrapping="Wrap" VerticalAlignment="Top">
                 Buttplug and the corresponding applications and libraries are provided open source and free of charge. 

--- a/ButtplugControlLibrary/ButtplugAboutControl.xaml.cs
+++ b/ButtplugControlLibrary/ButtplugAboutControl.xaml.cs
@@ -1,18 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace ButtplugControlLibrary
 {
@@ -71,6 +61,11 @@ namespace ButtplugControlLibrary
             }
             IconImage.MouseDown -= IconImage_Click;
             AboutImageClickedABunch?.Invoke(this, e);
+        }
+
+        private void LicenseHyperlink_Click(object sender, RoutedEventArgs e)
+        {
+            new LicenseView().Show();
         }
     }
 }

--- a/ButtplugControlLibrary/ButtplugControlLibrary.csproj
+++ b/ButtplugControlLibrary/ButtplugControlLibrary.csproj
@@ -79,8 +79,15 @@
       <DependentUpon>ButtplugLogControl.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="LicenseView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LicenseView.xaml.cs">
+      <DependentUpon>LicenseView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/ButtplugControlLibrary/LicenseView.xaml
+++ b/ButtplugControlLibrary/LicenseView.xaml
@@ -1,0 +1,13 @@
+﻿<Window x:Class="ButtplugControlLibrary.LicenseView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:ButtplugControlLibrary"
+        mc:Ignorable="d"
+        Title="Buttplug License Information" Height="400" Width="600">
+	<Grid>
+		<TextBox HorizontalAlignment="Stretch" Margin="10,10,10,10" TextWrapping="Wrap" Name="LicenseText" VerticalAlignment="Stretch" IsReadOnly="True" ScrollViewer.CanContentScroll="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"/>
+
+	</Grid>
+</Window>

--- a/ButtplugControlLibrary/LicenseView.xaml.cs
+++ b/ButtplugControlLibrary/LicenseView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using Buttplug.Core;
+using System.IO;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace ButtplugControlLibrary
+{
+    /// <summary>
+    /// Interaction logic for LicenseView.xaml
+    /// </summary>
+    public partial class LicenseView : Window
+    {
+        public LicenseView()
+        {
+            InitializeComponent();
+            ((TextBox)LicenseText).Text = ButtplugService.GetLicense();
+        }
+    }
+}

--- a/ButtplugTest/Core/ButtplugServerTests.cs
+++ b/ButtplugTest/Core/ButtplugServerTests.cs
@@ -195,5 +195,13 @@ namespace ButtplugTest.Core
                 msgReceived = false;
             }
         }
+
+        [Fact]
+        public void TestLicenseFileLoading()
+        {
+            var license = ButtplugService.GetLicense();
+            Assert.Contains("Buttplug is covered under the following BSD 3-Clause License", license);
+            Assert.Contains("NJsonSchema (https://github.com/RSuter/NJsonSchema) is covered under the", license);
+        }
     }
 }


### PR DESCRIPTION
The LICENSE file is now included within the Buttplug assembly so that we don't need to update multiple locations.

Fixes issue #53