### PR TITLE
fix: Fix null check for websocket server on stop

### DIFF
--- a/ButtplugWebsockets/ButtplugWebsocketServer.cs
+++ b/ButtplugWebsockets/ButtplugWebsocketServer.cs
@@ -13,10 +13,6 @@ namespace ButtplugWebsockets
     {
         private HttpServer _wsServer;
 
-        public ButtplugWebsocketServer()
-        {
-        }
-
         public void StartServer([NotNull] ButtplugService aService, int port = 12345, bool secure = false)
         {
             _wsServer = new HttpServer(port, secure);
@@ -32,6 +28,10 @@ namespace ButtplugWebsockets
 
         public void StopServer()
         {
+            if (_wsServer is null)
+            {
+                return;
+            }
             _wsServer.Stop();
             _wsServer.RemoveWebSocketService("/buttplug");
             _wsServer = null;


### PR DESCRIPTION
If a stop of the websocket server is somehow requested twice, the
object will be null and can cause a crash. Check to make sure the
server is not null before stopping.

Fixes #128