### PR TITLE
Handling address already in use error

### DIFF
--- a/ButtplugServerGUI/WebsocketServerControl.xaml.cs
+++ b/ButtplugServerGUI/WebsocketServerControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Buttplug.Core;
 using ButtplugWebsockets;
+using System.Net.Sockets;
 
 namespace ButtplugServerGUI
 {
@@ -41,10 +42,17 @@ namespace ButtplugServerGUI
 
         public void StartServer()
         {
-            _ws.StartServer(_bpFactory, (int)_port, _secure);
-            ConnToggleButton.Content = "Stop";
-            SecureCheckBox.IsEnabled = false;
-            PortTextBox.IsEnabled = false;
+            try
+            {
+                _ws.StartServer(_bpFactory, (int)_port, _secure);
+                ConnToggleButton.Content = "Stop";
+                SecureCheckBox.IsEnabled = false;
+                PortTextBox.IsEnabled = false;
+            }
+            catch (SocketException e)
+            {
+                MessageBox.Show(e.Message, "Buttplug Error", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+            }
         }
 
         public void StopServer()


### PR DESCRIPTION
We know that this can happen if 2 instances of the server
are started at the same time. In this case a SocketException
is thown. This change wraps that in a MessageBox.

Other exceptions still throw, and go to sentry.

Fix for #139