### PR TITLE
build: Make appveyor only build once on PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ skip_commits:
   files:
     - README.md
 
+skip_branch_with_pr: true
+  
 # Taken from https://boblokerse.github.io/2015/11/03/GitVersion-versioning-made-easy-and-dry/
 install:
   - ver


### PR DESCRIPTION
Added appveyor config to skip a branch build when a PR on a branch is
sent.

Fixes #146