### PR TITLE
Fixing an issue where no RequestDeviceList() would throw a NPE

### DIFF
--- a/Buttplug.Client.Test/ButtPlugClientTests.cs
+++ b/Buttplug.Client.Test/ButtPlugClientTests.cs
@@ -58,6 +58,8 @@ namespace Buttplug.Client.Test
 
             Assert.True(client.nextMsgId > 4);
 
+            await client.RequestDeviceList();
+
             Console.WriteLine("FINISHED CLIENT DISCONNECT");
 
             // Shut it down

--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -290,6 +290,11 @@ namespace Buttplug.Client
         public async Task RequestDeviceList()
         {
             var deviceList = (await SendMessage(new RequestDeviceList(nextMsgId))) as DeviceList;
+            if (deviceList.Devices == null)
+            {
+                return;
+            }
+
             foreach (var d in deviceList.Devices)
             {
                 if (!_devices.ContainsKey(d.DeviceIndex))

--- a/app.reg
+++ b/app.reg
@@ -19,3 +19,6 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Classes\AppID\ButtplugServerGUI.exe]
 "AppID"="{415579bd-5399-48ef-8521-775ebcd647af}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\AppID\ButtplugWebsocketServerGUI.exe]
+"AppID"="{415579bd-5399-48ef-8521-775ebcd647af}"


### PR DESCRIPTION
If the server has no devices, the device list within the deserialized message
will be set to null rather than an empty list. Checking for null avoids the NPE.