### PR TITLE
Correcting the JSON deserialization for arrays

### DIFF
--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -273,7 +273,7 @@ namespace Buttplug.Client
                 {
                     _owningDispatcher.Invoke(() =>
                     {
-                        ErrorReceived?.Invoke(this, new ErrorEventArgs((msg as Error)));
+                        ErrorReceived?.Invoke(this, new ErrorEventArgs(msg as Error));
                     });
                     throw new Exception((msg as Error).ErrorMessage);
                 }

--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -289,13 +289,21 @@ namespace Buttplug.Client
 
         public async Task RequestDeviceList()
         {
-            var deviceList = (await SendMessage(new RequestDeviceList(nextMsgId))) as DeviceList;
-            if (deviceList.Devices == null)
+            var resp = await SendMessage(new RequestDeviceList(nextMsgId));
+            if (!(resp is DeviceList) || (resp as DeviceList).Devices == null)
             {
+                if (resp is Error)
+                {
+                    _owningDispatcher.Invoke(() =>
+                    {
+                        ErrorReceived?.Invoke(this, new ErrorEventArgs(resp as Error));
+                    });
+                }
+
                 return;
             }
 
-            foreach (var d in deviceList.Devices)
+            foreach (var d in (resp as DeviceList).Devices)
             {
                 if (!_devices.ContainsKey(d.DeviceIndex))
                 {

--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
@@ -50,6 +50,7 @@ namespace Buttplug.Components.Controls
             {
                 _guiLog.Error("Sentry URL invalid, cannot submit crash reports!");
             }
+
             // Cover all of the possible bases for WPF failure
             // http://stackoverflow.com/questions/12024470/unhandled-exception-still-crashes-application-after-being-caught
             AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledException;

--- a/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
+++ b/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
@@ -111,6 +111,7 @@ namespace Buttplug.Components.WebsocketServer
             finally
             {
                 buttplug.MessageReceived -= msgReceived;
+                buttplug.Shutdown();
                 buttplug = null;
                 ws.Dispose();
             }

--- a/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
+++ b/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
@@ -2,10 +2,10 @@
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Buttplug.Core.Messages;
 using Buttplug.Server;
 using JetBrains.Annotations;
 using vtortola.WebSockets;
-using Buttplug.Core.Messages;
 
 namespace Buttplug.Components.WebsocketServer
 {
@@ -105,8 +105,14 @@ namespace Buttplug.Components.WebsocketServer
             catch (Exception)
             {
                 // TODO Log here.
-                try { ws.Close(); }
-                catch { }
+                try
+                {
+                    ws.Close();
+                }
+                catch
+                {
+                    // noop
+                }
             }
             finally
             {

--- a/Buttplug.Core/ButtplugDevice.cs
+++ b/Buttplug.Core/ButtplugDevice.cs
@@ -67,5 +67,7 @@ namespace Buttplug.Core
             // ReSharper disable once AssignNullToNotNullAttribute
             return Task.FromResult<ButtplugMessage>(new Ok(ButtplugConsts.SystemMsgId));
         }
+
+        public abstract void Disconnect();
     }
 }

--- a/Buttplug.Core/ButtplugLog.cs
+++ b/Buttplug.Core/ButtplugLog.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Buttplug.Logging;
 using Buttplug.Core.Messages;
+using Buttplug.Logging;
 using JetBrains.Annotations;
 using static Buttplug.Core.Messages.Error;
 

--- a/Buttplug.Core/IButtplugDevice.cs
+++ b/Buttplug.Core/IButtplugDevice.cs
@@ -24,5 +24,7 @@ namespace Buttplug.Core
 
         [NotNull]
         Task<ButtplugMessage> Initialize();
+
+        void Disconnect();
     }
 }

--- a/Buttplug.Core/Messages/Messages.cs
+++ b/Buttplug.Core/Messages/Messages.cs
@@ -76,11 +76,14 @@ namespace Buttplug.Core.Messages
 
     public class DeviceMessageInfo
     {
+        [JsonProperty(Required = Required.Always)]
         public string DeviceName;
 
+        [JsonProperty(Required = Required.Always)]
         public uint DeviceIndex;
 
-        public string[] DeviceMessages;
+        [JsonProperty(Required = Required.Always, NullValueHandling = NullValueHandling.Ignore)]
+        public string[] DeviceMessages = new string[0];
 
         public DeviceMessageInfo(uint aIndex, string aName, string[] aMessages)
         {
@@ -92,7 +95,8 @@ namespace Buttplug.Core.Messages
 
     public class DeviceList : ButtplugMessage, IButtplugMessageOutgoingOnly
     {
-        public readonly DeviceMessageInfo[] Devices;
+        [JsonProperty(Required = Required.Always, NullValueHandling = NullValueHandling.Ignore)]
+        public readonly DeviceMessageInfo[] Devices = new DeviceMessageInfo[0];
 
         public DeviceList(DeviceMessageInfo[] aDeviceList, uint aId)
              : base(aId)
@@ -103,9 +107,11 @@ namespace Buttplug.Core.Messages
 
     public class DeviceAdded : ButtplugDeviceMessage, IButtplugMessageOutgoingOnly
     {
+        [JsonProperty(Required = Required.Always)]
         public string DeviceName;
 
-        public string[] DeviceMessages;
+        [JsonProperty(Required = Required.Always, NullValueHandling = NullValueHandling.Ignore)]
+        public string[] DeviceMessages = new string[0];
 
         public DeviceAdded(uint aIndex, string aName, string[] aMessages)
             : base(ButtplugConsts.SystemMsgId, aIndex)
@@ -117,6 +123,7 @@ namespace Buttplug.Core.Messages
 
     public class DeviceRemoved : ButtplugMessage, IButtplugMessageOutgoingOnly
     {
+        [JsonProperty(Required = Required.Always)]
         public uint DeviceIndex;
 
         public DeviceRemoved(uint aIndex)
@@ -187,11 +194,11 @@ namespace Buttplug.Core.Messages
 
     public class Log : ButtplugMessage, IButtplugMessageOutgoingOnly
     {
+        [JsonProperty(Required = Required.Always)]
         public ButtplugLogLevel LogLevel;
 
-        // Needs to be left in for serialization
-        // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        private string LogMessage;
+        [JsonProperty(Required = Required.Always)]
+        public string LogMessage;
 
         public Log(ButtplugLogLevel aLogLevel, string aLogMessage)
             : base(ButtplugConsts.SystemMsgId)

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceFactory.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceFactory.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Buttplug.Server.Bluetooth;
 using Buttplug.Core;
 using Buttplug.Core.Messages;
+using Buttplug.Server.Bluetooth;
 using JetBrains.Annotations;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.Advertisement;

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
-using Buttplug.Server.Bluetooth;
 using Buttplug.Core;
 using Buttplug.Core.Messages;
+using Buttplug.Server.Bluetooth;
 using JetBrains.Annotations;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.GenericAttributeProfile;
@@ -15,12 +15,15 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
     {
         public string Name => _bleDevice.Name;
 
-        [CanBeNull]
-        private BluetoothLEDevice _bleDevice;
         [NotNull]
         private readonly GattCharacteristic[] _gattCharacteristics;
+
+        [CanBeNull]
+        private BluetoothLEDevice _bleDevice;
+
         [NotNull]
         private readonly IButtplugLog _bpLogger;
+
         [CanBeNull]
         private IAsyncOperation<GattCommunicationStatus> _currentTask;
 

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
@@ -15,8 +15,8 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
     {
         public string Name => _bleDevice.Name;
 
-        [NotNull]
-        private readonly BluetoothLEDevice _bleDevice;
+        [CanBeNull]
+        private BluetoothLEDevice _bleDevice;
         [NotNull]
         private readonly GattCharacteristic[] _gattCharacteristics;
         [NotNull]
@@ -40,7 +40,7 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
 
         private void ConnectionStatusChangedHandler([NotNull] BluetoothLEDevice aDevice, [NotNull] object aObj)
         {
-            if (_bleDevice.ConnectionStatus == BluetoothConnectionStatus.Disconnected)
+            if (_bleDevice?.ConnectionStatus == BluetoothConnectionStatus.Disconnected)
             {
                 DeviceRemoved?.Invoke(this, new EventArgs());
             }
@@ -86,6 +86,18 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
             }
 
             return new Ok(aMsgId);
+        }
+
+        public void Disconnect()
+        {
+            DeviceRemoved?.Invoke(this, new EventArgs());
+            for (int i = 0; i < _gattCharacteristics.Length; i++)
+            {
+                _gattCharacteristics[i] = null;
+            }
+
+            _bleDevice.Dispose();
+            _bleDevice = null;
         }
     }
 }

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothManager.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothManager.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Buttplug.Server.Bluetooth;
 using Buttplug.Core;
+using Buttplug.Server.Bluetooth;
 using JetBrains.Annotations;
 using Microsoft.Win32;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.Advertisement;
-using Buttplug.Server;
 
 namespace Buttplug.Server.Managers.UWPBluetoothManager
 {

--- a/Buttplug.Server.Test/ButtplugDeviceTests.cs
+++ b/Buttplug.Server.Test/ButtplugDeviceTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
-using Buttplug.Server.Bluetooth;
 using Buttplug.Core;
+using Buttplug.Server.Bluetooth;
 using Xunit;
 
 namespace Buttplug.Server.Test

--- a/Buttplug.Server.Test/TestBluetoothSubtypeManager.cs
+++ b/Buttplug.Server.Test/TestBluetoothSubtypeManager.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Buttplug.Server.Bluetooth;
 using Buttplug.Core;
+using Buttplug.Server.Bluetooth;
 
 namespace Buttplug.Server.Test
 {

--- a/Buttplug.Server.Test/TestDevice.cs
+++ b/Buttplug.Server.Test/TestDevice.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Buttplug.Core;
 using Buttplug.Core.Messages;
 
@@ -21,6 +22,11 @@ namespace Buttplug.Server.Test
         public void RemoveDevice()
         {
             InvokeDeviceRemoved();
+        }
+
+        public override void Disconnect()
+        {
+            RemoveDevice();
         }
     }
 }

--- a/Buttplug.Server/Bluetooth/ButtplugBluetoothDevice.cs
+++ b/Buttplug.Server/Bluetooth/ButtplugBluetoothDevice.cs
@@ -20,6 +20,11 @@ namespace Buttplug.Server.Bluetooth
             Interface.DeviceRemoved += DeviceRemovedHandler;
         }
 
+        public override void Disconnect()
+        {
+            Interface.Disconnect();
+        }
+
         private void DeviceRemovedHandler(object aObject, EventArgs aEvent)
         {
             InvokeDeviceRemoved();

--- a/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
+++ b/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
@@ -13,5 +13,7 @@ namespace Buttplug.Server.Bluetooth
         ulong GetAddress();
 
         event EventHandler DeviceRemoved;
+
+        void Disconnect();
     }
 }

--- a/Buttplug.Server/ButtplugService.cs
+++ b/Buttplug.Server/ButtplugService.cs
@@ -153,6 +153,11 @@ namespace Buttplug.Server
             return await _deviceManager.SendMessage(aMsg);
         }
 
+        public void Shutdown()
+        {
+            _deviceManager.RemoveAllDevices();
+        }
+
         [ItemNotNull]
         public async Task<ButtplugMessage[]> SendMessage(string aJsonMsgs)
         {

--- a/Buttplug.Server/DeviceManager.cs
+++ b/Buttplug.Server/DeviceManager.cs
@@ -174,6 +174,15 @@ namespace Buttplug.Server
             return _bpLogger.LogErrorMsg(id, Error.ErrorClass.ERROR_MSG, $"Message type {aMsg.GetType().Name} unhandled by this server.");
         }
 
+        internal void RemoveAllDevices()
+        {
+            StopScanning();
+            foreach (var d in _devices.Values)
+            {
+                d.Disconnect();
+            }
+        }
+
         private void StartScanning()
         {
             _sentFinished = false;


### PR DESCRIPTION
Fixes #176 by telling JSON.net to ignore null values
Fixes #158 by changing the scope of the LogMessage field
Fixes #170 by passing disconnect calls back up to devices