### PR TITLE
Making it easier to get started with HTTPS

### DIFF
--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
@@ -5,16 +5,31 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
             d:DesignHeight="300" d:DesignWidth="525">
-	<Grid Background="#FFE5E5E5" >
+	<Grid Background="#FFE5E5E5" Margin="0,-1,0,1" >
 		<Grid.RowDefinitions>
 			<RowDefinition Height="45"/>
 			<RowDefinition Height="25"/>
+			<RowDefinition Height="auto"/>
 		</Grid.RowDefinitions>
 		<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
 		<TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" TextChanged="PortTextBox_TextChanged"/>
 		<CheckBox Name="SecureCheckBox"  Grid.Row="0" Content="SSL/TLS" HorizontalAlignment="Right" Margin="0,17,10,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
 		
 		<Button Name="ConnToggleButton"  Grid.Row="1" Content="Start" HorizontalAlignment="Right" Margin="0,0,10,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
+		<GroupBox Header="Connection Details" Grid.Row="2" Margin="10,0" VerticalAlignment="Top" Name="ConnInfo">
+			<Grid Background="#FFE5E5E5" >
+				<Grid.RowDefinitions>
+					<RowDefinition Height="auto"/>
+					<RowDefinition Height="auto"/>
+				</Grid.RowDefinitions>
+				<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
+				<TextBox Name="ConnectionUrl" Grid.Row="0" Height="23" Margin="104,14,0,-18" TextWrapping="Wrap" VerticalAlignment="Top" Text="ws://localhost:12345/buttplug" IsReadOnly="True"/>
+
+				<Label Content="Test URL:"  Grid.Row="1" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
+				<TextBlock Grid.Row="1" Height="23" Margin="104,10,0,-18"  VerticalAlignment="Top" ><Hyperlink Name="TestUrl" NavigateUri="http://localhost:12345" RequestNavigate="TestUrl_RequestNavigate">http://localhost:12345</Hyperlink></TextBlock>
+
+			</Grid>
+		</GroupBox>
 
 	</Grid>
 </UserControl>

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -39,6 +39,14 @@ namespace Buttplug.Apps.WebsocketServerGUI
 
             PortTextBox.Text = _port.ToString();
             SecureCheckBox.IsChecked = _secure;
+
+            _ws.OnException += WebSocketExceptionHandler;
+        }
+
+        private void WebSocketExceptionHandler(object aObj, UnhandledExceptionEventArgs aEx)
+        {
+            Console.WriteLine("Exception of type " + aEx.ExceptionObject.GetType().ToString() + " encountered: " + (aEx.ExceptionObject as Exception)?.Message ?? "Unknown");
+            MessageBox.Show((aEx.ExceptionObject as Exception)?.Message ?? "Unknown", "Connection Error", MessageBoxButton.OK, MessageBoxImage.Exclamation);
         }
 
         public void StartServer()

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using System.Windows.Controls;
 using Buttplug.Components.WebsocketServer;
 using Buttplug.Server;
+using System.Windows.Input;
+using System;
 
 namespace Buttplug.Apps.WebsocketServerGUI
 {
@@ -47,6 +49,10 @@ namespace Buttplug.Apps.WebsocketServerGUI
                 ConnToggleButton.Content = "Stop";
                 SecureCheckBox.IsEnabled = false;
                 PortTextBox.IsEnabled = false;
+                ConnectionUrl.Text = (_secure ? "wss" : "ws") + "://localhost:" + _port.ToString() + "/buttplug";
+                TestUrl.Inlines.Clear();
+                TestUrl.Inlines.Add((_secure ? "https" : "http") + "://localhost:" + _port.ToString());
+                ConnInfo.Visibility = Visibility.Visible;
             }
             catch (SocketException e)
             {
@@ -60,6 +66,7 @@ namespace Buttplug.Apps.WebsocketServerGUI
             ConnToggleButton.Content = "Start";
             SecureCheckBox.IsEnabled = true;
             PortTextBox.IsEnabled = true;
+            ConnInfo.Visibility = Visibility.Collapsed;
         }
 
         private void ConnToggleButton_Click(object aObj, RoutedEventArgs aEvent)
@@ -95,6 +102,11 @@ namespace Buttplug.Apps.WebsocketServerGUI
         private void SecureCheckBox_Checked(object aObj, RoutedEventArgs aEvent)
         {
             _secure = true;
+        }
+
+        private void TestUrl_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        {
+            System.Diagnostics.Process.Start(new Uri((_secure ? "https" : "http") + "://localhost:" + _port.ToString()).AbsoluteUri);
         }
     }
 }

--- a/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
+++ b/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
@@ -15,6 +15,9 @@ namespace Buttplug.Components.WebsocketServer
         [NotNull]
         private IButtplugServiceFactory _factory;
 
+        [CanBeNull]
+        public EventHandler<UnhandledExceptionEventArgs> OnException;
+
         public void StartServer([NotNull] IButtplugServiceFactory aFactory, int aPort = 12345, bool aSecure = false)
         {
             CancellationTokenSource cancellation = new CancellationTokenSource();
@@ -49,7 +52,7 @@ namespace Buttplug.Components.WebsocketServer
                 }
                 catch (Exception aEx)
                 {
-                    // TODO: Actually log here.
+                    OnException?.Invoke(this, new UnhandledExceptionEventArgs(aEx, false));
                 }
             }
         }


### PR DESCRIPTION
This adds a connection details section to the server tab to make it quicker and easier to get you're certs installed and get your client attached to the server.

Additionally, the Buttplug Server get noisy if things go wrong during client connection.