### PR TITLE
Adding Vibratissimo support

### DIFF
--- a/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
+++ b/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
@@ -25,6 +25,7 @@ namespace Buttplug.Server.Bluetooth
                 new LovenseRev1BluetoothInfo(),
                 new LovenseRev2BluetoothInfo(),
                 new LovenseRev3BluetoothInfo(),
+                new VibratissimoBluetoothInfo(),
                 new VorzeA10CycloneInfo(),
             };
         }

--- a/Buttplug.Server/Bluetooth/Devices/Vibratissimo.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Vibratissimo.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Buttplug.Core;
+using Buttplug.Core.Messages;
+
+namespace Buttplug.Server.Bluetooth.Devices
+{
+    internal class VibratissimoBluetoothInfo : IBluetoothDeviceInfo
+    {
+        public enum Chrs : uint
+        {
+            TxMode = 0,
+            TxSpeed,
+            Rx,
+        }
+
+        public Guid[] Services { get; } = { new Guid("00001523-1212-efde-1523-785feabcd123") };
+
+        // Deliberately empty: you can rename these!
+        public string[] Names { get; } =
+        {
+        };
+
+        public Guid[] Characteristics { get; } =
+        {
+            // tx characteristic
+            new Guid("00001524-1212-efde-1523-785feabcd123"),
+            new Guid("00001526-1212-efde-1523-785feabcd123"),
+
+            // rx characteristic
+            new Guid("00001527-1212-efde-1523-785feabcd123"),
+        };
+
+        public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
+            IBluetoothDeviceInterface aInterface)
+        {
+            return new Vibratissimo(aLogManager,
+                aInterface);
+        }
+    }
+
+    internal class Vibratissimo : ButtplugBluetoothDevice
+    {
+        public Vibratissimo(IButtplugLogManager aLogManager,
+                       IBluetoothDeviceInterface aInterface)
+            : base(aLogManager,
+                   $"Vibratissimo Device ({aInterface.Name})",
+                   aInterface)
+        {
+            MsgFuncs.Add(typeof(SingleMotorVibrateCmd), HandleSingleMotorVibrateCmd);
+            MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
+        }
+
+        private async Task<ButtplugMessage> HandleStopDeviceCmd(ButtplugDeviceMessage aMsg)
+        {
+            return await HandleSingleMotorVibrateCmd(new SingleMotorVibrateCmd(aMsg.DeviceIndex, 0, aMsg.Id));
+        }
+
+        private async Task<ButtplugMessage> HandleSingleMotorVibrateCmd(ButtplugDeviceMessage aMsg)
+        {
+            var cmdMsg = aMsg as SingleMotorVibrateCmd;
+            if (cmdMsg is null)
+            {
+                return BpLogger.LogErrorMsg(aMsg.Id, Error.ErrorClass.ERROR_DEVICE, "Wrong Handler");
+            }
+
+            var data = new byte[2];
+            data[0] = 0x03;
+            data[1] = 0xFF;
+            await Interface.WriteValue(aMsg.Id, (uint)VibratissimoBluetoothInfo.Chrs.TxMode, data);
+
+            data[0] = Convert.ToByte(cmdMsg.Speed * byte.MaxValue);
+            data[1] = 0x00;
+            return await Interface.WriteValue(aMsg.Id, (uint)VibratissimoBluetoothInfo.Chrs.TxSpeed, data);
+        }
+    }
+}

--- a/Buttplug.Server/Buttplug.Server.csproj
+++ b/Buttplug.Server/Buttplug.Server.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Bluetooth\ButtplugBluetoothDevice.cs" />
     <Compile Include="Bluetooth\Devices\FleshlightLaunch.cs" />
     <Compile Include="Bluetooth\Devices\Kiiroo.cs" />
+    <Compile Include="Bluetooth\Devices\Vibratissimo.cs" />
     <Compile Include="Bluetooth\Devices\Lovense.cs" />
     <Compile Include="Bluetooth\Devices\VorzeA10Cyclone.cs" />
     <Compile Include="Bluetooth\IBluetoothDeviceInfo.cs" />


### PR DESCRIPTION
Fun fact: you can change the BLE names on these devices!
This meant adding a bit more support to the device factory for
service uuid matching.

Other than that, implementation is as documented here:
  https://metafetish.github.io/vibrato-docs/bluetooth.html