### PR TITLE
Correcting the SSL cert  subjects

### DIFF
--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -19,6 +19,7 @@ namespace Buttplug.Apps.WebsocketServerGUI
         private readonly ButtplugConfig _config;
         private uint _port;
         private bool _secure;
+        private string _hostname;
 
         public WebsocketServerControl(IButtplugServerFactory bpFactory)
         {
@@ -27,16 +28,18 @@ namespace Buttplug.Apps.WebsocketServerGUI
             _bpFactory = bpFactory;
             _config = new ButtplugConfig("Buttplug");
             _port = 12345;
-            _secure = false;
             if (uint.TryParse(_config.GetValue("buttplug.server.port", "12345"), out uint pres))
             {
                 _port = pres;
             }
 
+            _secure = false;
             if (bool.TryParse(_config.GetValue("buttplug.server.secure", "false"), out bool sres))
             {
                 _secure = sres;
             }
+
+            _hostname = _config.GetValue("buttplug.server.hostname", "localhost");
 
             PortTextBox.Text = _port.ToString();
             SecureCheckBox.IsChecked = _secure;
@@ -55,7 +58,7 @@ namespace Buttplug.Apps.WebsocketServerGUI
         {
             try
             {
-                _ws.StartServer(_bpFactory, (int)_port, _secure);
+                _ws.StartServer(_bpFactory, (int)_port, _secure, _hostname);
                 ConnToggleButton.Content = "Stop";
                 SecureCheckBox.IsEnabled = false;
                 PortTextBox.IsEnabled = false;

--- a/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
+++ b/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
@@ -18,7 +18,7 @@ namespace Buttplug.Components.WebsocketServer
         [CanBeNull]
         public EventHandler<UnhandledExceptionEventArgs> OnException;
 
-        public void StartServer([NotNull] IButtplugServerFactory aFactory, int aPort = 12345, bool aSecure = false)
+        public void StartServer([NotNull] IButtplugServerFactory aFactory, int aPort = 12345, bool aSecure = false, string aHostname = "localhost")
         {
             CancellationTokenSource cancellation = new CancellationTokenSource();
             _factory = aFactory;
@@ -29,7 +29,7 @@ namespace Buttplug.Components.WebsocketServer
             _server.Standards.RegisterStandard(rfc6455);
             if (aSecure)
             {
-                var cert = CertUtils.GetCert("Buttplug");
+                var cert = CertUtils.GetCert("Buttplug", aHostname);
                 _server.ConnectionExtensions.RegisterExtension(new WebSocketSecureConnectionExtension(cert));
             }
 


### PR DESCRIPTION
This fixes #198 by implenting the example @funjack provided.
There were additional issues with the cert chain too.

If neither the local hostname, 'localhost' or the loopback IP are not
resolving correctly, a hostame option can be set in %appdata%\buttplug\config.json. For example:
```
{
  "buttplug": {
    "server": {
      "port": "12345",
      "secure": "True",
      "maxPing": "0",
      "hostname": "foo.example.org"
    }
  }
}
```