### PR TITLE
Preventing multiple simultaneous connections to the server

### DIFF
--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
@@ -21,6 +21,7 @@
 				<Grid.RowDefinitions>
 					<RowDefinition Height="auto"/>
 					<RowDefinition Height="auto"/>
+					<RowDefinition Height="auto"/>
 				</Grid.RowDefinitions>
 				<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
 				<TextBox Name="ConnectionUrl" Grid.Row="0" Height="23" Margin="104,14,0,-18" TextWrapping="Wrap" VerticalAlignment="Top" Text="ws://localhost:12345/buttplug" IsReadOnly="True"/>
@@ -28,6 +29,8 @@
 				<Label Content="Test URL:"  Grid.Row="1" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
 				<TextBlock Grid.Row="1" Height="23" Margin="104,10,0,-18"  VerticalAlignment="Top" ><Hyperlink Name="TestUrl" NavigateUri="http://localhost:12345" RequestNavigate="TestUrl_RequestNavigate">http://localhost:12345</Hyperlink></TextBlock>
 
+				<Label Content="Status:"  Grid.Row="2" HorizontalAlignment="Left" Margin="10,0,0,0" VerticalAlignment="Top"/>
+				<Label Name="ConnStatus" Content="(Not Connected)" Grid.Row="2" HorizontalAlignment="Left" Margin="100,00,0,0" VerticalAlignment="Top"/>
 			</Grid>
 		</GroupBox>
 

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -1,9 +1,9 @@
-﻿using System.Net.Sockets;
+﻿using System;
+using System.Net.Sockets;
 using System.Windows;
 using System.Windows.Controls;
 using Buttplug.Components.WebsocketServer;
 using Buttplug.Server;
-using System;
 using JetBrains.Annotations;
 using NLog;
 
@@ -45,6 +45,9 @@ namespace Buttplug.Apps.WebsocketServerGUI
             SecureCheckBox.IsChecked = _secure;
 
             _ws.OnException += WebSocketExceptionHandler;
+            _ws.ConnectionAccepted += WebSocketConnectionAccepted;
+            _ws.ConnectionUpdated += WebSocketConnectionAccepted;
+            _ws.ConnectionClosed += WebSocketConnectionClosed;
         }
 
         private void WebSocketExceptionHandler(object aObj, [NotNull] UnhandledExceptionEventArgs aEx)
@@ -52,6 +55,22 @@ namespace Buttplug.Apps.WebsocketServerGUI
             var log = LogManager.GetCurrentClassLogger();
             log.Error("Exception of type " + aEx.ExceptionObject.GetType() + " encountered: " + (aEx.ExceptionObject as Exception)?.Message);
             MessageBox.Show((aEx.ExceptionObject as Exception)?.Message ?? "Unknown", "Connection Error", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+        }
+
+        private void WebSocketConnectionAccepted(object aObj, [NotNull] ConnectionEventArgs aEvent)
+        {
+            Dispatcher.InvokeAsync(() =>
+            {
+                ConnStatus.Content = "(Connected) " + aEvent.ClientName;
+            });
+        }
+
+        private void WebSocketConnectionClosed(object aObj, [NotNull] ConnectionEventArgs aEvent)
+        {
+            Dispatcher.InvokeAsync(() =>
+            {
+                ConnStatus.Content = "(Not Connected)";
+            });
         }
 
         public void StartServer()

--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
@@ -84,6 +84,7 @@ namespace Buttplug.Components.Controls
         {
             // Set up internal services
             ButtplugServer bpServer;
+
             // Due to the weird inability to close BLE devices, we have to share device managers across buttplug
             // server instances. Otherwise we'll just hold device connections open forever.
             if (_deviceManager == null)
@@ -96,6 +97,7 @@ namespace Buttplug.Components.Controls
                 bpServer = new ButtplugServer(aServerName, aMaxPingTime, _deviceManager);
                 return bpServer;
             }
+
             if (!(Environment.OSVersion is null))
             {
                 _guiLog.Info($"Windows Version: {Environment.OSVersion.VersionString}");

--- a/Buttplug.Components.WebsocketServer/Buttplug.Components.WebsocketServer.csproj
+++ b/Buttplug.Components.WebsocketServer/Buttplug.Components.WebsocketServer.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="ButtplugWebsocketServer.cs" />
     <Compile Include="CertUtils.cs" />
+    <Compile Include="ConnectionEventArgs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Buttplug.Components.WebsocketServer/CertUtils.cs
+++ b/Buttplug.Components.WebsocketServer/CertUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -15,7 +16,6 @@ using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities;
 using Org.BouncyCastle.X509;
-using System.Collections.Generic;
 
 namespace Buttplug.Components.WebsocketServer
 {

--- a/Buttplug.Components.WebsocketServer/ConnectionEventArgs.cs
+++ b/Buttplug.Components.WebsocketServer/ConnectionEventArgs.cs
@@ -1,0 +1,19 @@
+﻿using JetBrains.Annotations;
+
+namespace Buttplug.Components.WebsocketServer
+{
+    public class ConnectionEventArgs
+    {
+        [NotNull]
+        public string ConnId;
+
+        [NotNull]
+        public string ClientName;
+
+        public ConnectionEventArgs(string aConnId, string aClientName = "Unknown Client")
+        {
+            ConnId = aConnId;
+            ClientName = aClientName;
+        }
+    }
+}

--- a/Buttplug.Core/ButtplugLog.cs
+++ b/Buttplug.Core/ButtplugLog.cs
@@ -83,5 +83,10 @@ namespace Buttplug.Core
             Warn(aMsg, false);
             return new Error(aMsg, aCode, aId);
         }
+
+        public void LogException(Exception aEx, bool aLocalOnly = true)
+        {
+            Error(aEx.GetType().ToString() + ": " + aEx.Message + "\n" + aEx.StackTrace, aLocalOnly);
+        }
     }
 }

--- a/Buttplug.Core/IButtplugLog.cs
+++ b/Buttplug.Core/IButtplugLog.cs
@@ -1,5 +1,6 @@
 ﻿using Buttplug.Core.Messages;
 using JetBrains.Annotations;
+using System;
 using static Buttplug.Core.Messages.Error;
 
 namespace Buttplug.Core
@@ -19,6 +20,8 @@ namespace Buttplug.Core
         // Fatal is kept here for completeness, even if it is not yet used.
         // ReSharper disable once UnusedMember.Global
         void Fatal(string aMsg, bool aLocalOnly = false);
+
+        void LogException(Exception aMsg, bool aLocalOnly = true);
 
         [NotNull]
         Error LogErrorMsg(uint aId, ErrorClass aCode, string aMsg);

--- a/Buttplug.Server/ButtplugServer.cs
+++ b/Buttplug.Server/ButtplugServer.cs
@@ -18,6 +18,9 @@ namespace Buttplug.Server
         [CanBeNull]
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
 
+        [CanBeNull]
+        public event EventHandler<MessageReceivedEventArgs> ClientConnected;
+
         [NotNull]
         private readonly IButtplugLog _bpLogger;
         [NotNull]
@@ -80,6 +83,7 @@ namespace Buttplug.Server
             {
                 _deviceManager = new DeviceManager(_bpLogManager);
             }
+
             _bpLogger.Trace("Finished setting up ButtplugServer");
             _deviceManager.DeviceMessageReceived += DeviceMessageReceivedHandler;
             _deviceManager.ScanningFinished += ScanningFinishedHandler;
@@ -154,9 +158,10 @@ namespace Buttplug.Server
 
                     return new Ok(id);
 
-                case RequestServerInfo _:
+                case RequestServerInfo rsi:
                     _receivedRequestServerInfo = true;
                     _pingTimer?.Start();
+                    ClientConnected?.Invoke(this, new MessageReceivedEventArgs(rsi));
                     return new ServerInfo(_serverName, 1, _maxPingTime, id);
 
                 case Test m:
@@ -177,6 +182,7 @@ namespace Buttplug.Server
                 _bpLogger.Error("An error occured while stopping devices on shutdown.");
                 _bpLogger.Error((msg as Error).ErrorMessage);
             }
+
             _deviceManager.StopScanning();
             _deviceManager.DeviceMessageReceived -= DeviceMessageReceivedHandler;
             _deviceManager.ScanningFinished -= ScanningFinishedHandler;


### PR DESCRIPTION
Further connections will receive an Error object before the socket is closed.

Additionally, the Server tab now shows the current connection status (and the name of the client connected.

Fixes #196