### PR TITLE
fix: Change default ping time to 1s

### DIFF
--- a/Buttplug.Apps.WebsocketServerGUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/MainWindow.xaml.cs
@@ -13,7 +13,7 @@ namespace Buttplug.Apps.WebsocketServerGUI
         {
             var config = new ButtplugConfig("Buttplug");
             uint ping;
-            uint.TryParse(config.GetValue("buttplug.server.maxPing", "100"), out ping);
+            uint.TryParse(config.GetValue("buttplug.server.maxPing", "1000"), out ping);
 
             InitializeComponent();
 


### PR DESCRIPTION
Until we have dynamic ping adjustments, set ping time to something
slightly more forgiving so we can test over wifi.

Fixes #206