### PR TITLE
Wevibe support

### DIFF
--- a/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
+++ b/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
@@ -28,6 +28,7 @@ namespace Buttplug.Server.Bluetooth
                 new MagicMotionBluetoothInfo(),
                 new VibratissimoBluetoothInfo(),
                 new VorzeA10CycloneInfo(),
+                new WeVibeBluetoothInfo(),
             };
         }
     }

--- a/Buttplug.Server/Bluetooth/ButtplugBluetoothDevice.cs
+++ b/Buttplug.Server/Bluetooth/ButtplugBluetoothDevice.cs
@@ -9,14 +9,19 @@ namespace Buttplug.Server.Bluetooth
         [NotNull]
         protected readonly IBluetoothDeviceInterface Interface;
 
+        [NotNull]
+        protected readonly IBluetoothDeviceInfo Info;
+
         protected ButtplugBluetoothDevice([NotNull] IButtplugLogManager aLogManager,
             [NotNull] string aName,
-            [NotNull] IBluetoothDeviceInterface aInterface)
+            [NotNull] IBluetoothDeviceInterface aInterface,
+            [NotNull] IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    aName,
                    aInterface.GetAddress().ToString())
         {
             Interface = aInterface;
+            Info = aInfo;
             Interface.DeviceRemoved += DeviceRemovedHandler;
         }
 

--- a/Buttplug.Server/Bluetooth/Devices/FleshlightLaunch.cs
+++ b/Buttplug.Server/Bluetooth/Devices/FleshlightLaunch.cs
@@ -36,18 +36,19 @@ namespace Buttplug.Server.Bluetooth.Devices
             IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new FleshlightLaunch(aLogManager,
-                                        aInterface);
+            return new FleshlightLaunch(aLogManager, aInterface, this);
         }
     }
 
     internal class FleshlightLaunch : ButtplugBluetoothDevice
     {
         public FleshlightLaunch([NotNull] IButtplugLogManager aLogManager,
-                                [NotNull] IBluetoothDeviceInterface aInterface)
+                                [NotNull] IBluetoothDeviceInterface aInterface,
+                                [NotNull] IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    "Fleshlight Launch",
-                   aInterface)
+                   aInterface,
+                   aInfo)
         {
             // Setup message function array
             MsgFuncs.Add(typeof(FleshlightLaunchFW12Cmd), HandleFleshlightLaunchRawCmd);
@@ -58,7 +59,7 @@ namespace Buttplug.Server.Bluetooth.Devices
         {
             BpLogger.Trace($"Initializing {Name}");
             return await Interface.WriteValue(ButtplugConsts.SystemMsgId,
-                (uint)FleshlightLaunchBluetoothInfo.Chrs.Cmd,
+                Info.Characteristics[(uint)FleshlightLaunchBluetoothInfo.Chrs.Cmd],
                 new byte[] { 0 },
                 true);
         }
@@ -84,7 +85,7 @@ namespace Buttplug.Server.Bluetooth.Devices
             }
 
             return await Interface.WriteValue(aMsg.Id,
-                (uint)FleshlightLaunchBluetoothInfo.Chrs.Tx,
+                Info.Characteristics[(uint)FleshlightLaunchBluetoothInfo.Chrs.Tx],
                 new[] { (byte)cmdMsg.Position, (byte)cmdMsg.Speed });
         }
     }

--- a/Buttplug.Server/Bluetooth/Devices/Kiiroo.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Kiiroo.cs
@@ -31,17 +31,19 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new Kiiroo(aLogManager, aInterface);
+            return new Kiiroo(aLogManager, aInterface, this);
         }
     }
 
     internal class Kiiroo : ButtplugBluetoothDevice
     {
         public Kiiroo([NotNull] IButtplugLogManager aLogManager,
-                      [NotNull] IBluetoothDeviceInterface aInterface)
+                      [NotNull] IBluetoothDeviceInterface aInterface,
+                      [NotNull] IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    $"Kiiroo {aInterface.Name}",
-                   aInterface)
+                   aInterface,
+                   aInfo)
         {
             MsgFuncs.Add(typeof(KiirooCmd), HandleKiirooRawCmd);
             MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
@@ -65,8 +67,8 @@ namespace Buttplug.Server.Bluetooth.Devices
             }
 
             return await Interface.WriteValue(cmdMsg.Id,
-                                              (uint)KiirooBluetoothInfo.Chrs.Tx,
-                                              Encoding.ASCII.GetBytes($"{cmdMsg.Position},\n"));
+                Info.Characteristics[(uint)KiirooBluetoothInfo.Chrs.Tx],
+                Encoding.ASCII.GetBytes($"{cmdMsg.Position},\n"));
         }
     }
 }

--- a/Buttplug.Server/Bluetooth/Devices/Lovense.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Lovense.cs
@@ -42,8 +42,7 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new Lovense(aLogManager,
-                aInterface);
+            return new Lovense(aLogManager, aInterface, this);
         }
     }
 
@@ -78,8 +77,7 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new Lovense(aLogManager,
-                               aInterface);
+            return new Lovense(aLogManager, aInterface, this);
         }
     }
 
@@ -111,8 +109,7 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new Lovense(aLogManager,
-                aInterface);
+            return new Lovense(aLogManager, aInterface, this);
         }
     }
 
@@ -130,10 +127,12 @@ namespace Buttplug.Server.Bluetooth.Devices
         };
 
         public Lovense(IButtplugLogManager aLogManager,
-                       IBluetoothDeviceInterface aInterface)
+                       IBluetoothDeviceInterface aInterface,
+                       IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    $"Lovense Device ({FriendlyNames[aInterface.Name]})",
-                   aInterface)
+                   aInterface,
+                   aInfo)
         {
             MsgFuncs.Add(typeof(SingleMotorVibrateCmd), HandleSingleMotorVibrateCmd);
             MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
@@ -154,8 +153,9 @@ namespace Buttplug.Server.Bluetooth.Devices
             }
 
             // While there are 3 lovense revs right now, all of the characteristic arrays are the same.
-            return await Interface.WriteValue(aMsg.Id, (uint)LovenseRev1BluetoothInfo.Chrs.Tx,
-                                              Encoding.ASCII.GetBytes($"Vibrate:{(int)(cmdMsg.Speed * 20)};"));
+            return await Interface.WriteValue(aMsg.Id,
+                Info.Characteristics[(uint)LovenseRev1BluetoothInfo.Chrs.Tx],
+                Encoding.ASCII.GetBytes($"Vibrate:{(int)(cmdMsg.Speed * 20)};"));
         }
     }
 }

--- a/Buttplug.Server/Bluetooth/Devices/MagicMotion.cs
+++ b/Buttplug.Server/Bluetooth/Devices/MagicMotion.cs
@@ -35,9 +35,6 @@ namespace Buttplug.Server.Bluetooth.Devices
         public Guid[] Characteristics { get; } =
         {
             // tx characteristic
-            new Guid("78667579-7b48-43db-b8c5-7928a6b0a335"),
-
-            // other characteristic... this one's advertised
             new Guid("78667579-a914-49a4-8333-aa3c0cd8fedc"),
         };
 

--- a/Buttplug.Server/Bluetooth/Devices/MagicMotion.cs
+++ b/Buttplug.Server/Bluetooth/Devices/MagicMotion.cs
@@ -44,18 +44,19 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new MagicMotion(aLogManager,
-                aInterface);
+            return new MagicMotion(aLogManager, aInterface, this);
         }
     }
 
     internal class MagicMotion : ButtplugBluetoothDevice
     {
         public MagicMotion(IButtplugLogManager aLogManager,
-                       IBluetoothDeviceInterface aInterface)
+                           IBluetoothDeviceInterface aInterface,
+                           IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    $"MagicMotion Device ({aInterface.Name})",
-                   aInterface)
+                   aInterface,
+                   aInfo)
         {
             MsgFuncs.Add(typeof(SingleMotorVibrateCmd), HandleSingleMotorVibrateCmd);
             MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
@@ -78,7 +79,9 @@ namespace Buttplug.Server.Bluetooth.Devices
             data[9] = Convert.ToByte(cmdMsg.Speed * byte.MaxValue);
 
             // While there are 3 lovense revs right now, all of the characteristic arrays are the same.
-            return await Interface.WriteValue(aMsg.Id, (uint)MagicMotionBluetoothInfo.Chrs.Tx, data);
+            return await Interface.WriteValue(aMsg.Id,
+                Info.Characteristics[(uint)MagicMotionBluetoothInfo.Chrs.Tx],
+                data);
         }
     }
 }

--- a/Buttplug.Server/Bluetooth/Devices/Vibratissimo.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Vibratissimo.cs
@@ -35,18 +35,19 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new Vibratissimo(aLogManager,
-                aInterface);
+            return new Vibratissimo(aLogManager, aInterface, this);
         }
     }
 
     internal class Vibratissimo : ButtplugBluetoothDevice
     {
         public Vibratissimo(IButtplugLogManager aLogManager,
-                       IBluetoothDeviceInterface aInterface)
+                            IBluetoothDeviceInterface aInterface,
+                            IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    $"Vibratissimo Device ({aInterface.Name})",
-                   aInterface)
+                   aInterface,
+                   aInfo)
         {
             MsgFuncs.Add(typeof(SingleMotorVibrateCmd), HandleSingleMotorVibrateCmd);
             MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
@@ -69,11 +70,15 @@ namespace Buttplug.Server.Bluetooth.Devices
             var data = new byte[2];
             data[0] = 0x03;
             data[1] = 0xFF;
-            await Interface.WriteValue(aMsg.Id, (uint)VibratissimoBluetoothInfo.Chrs.TxMode, data);
+            await Interface.WriteValue(aMsg.Id,
+                Info.Characteristics[(uint)VibratissimoBluetoothInfo.Chrs.TxMode],
+                data);
 
             data[0] = Convert.ToByte(cmdMsg.Speed * byte.MaxValue);
             data[1] = 0x00;
-            return await Interface.WriteValue(aMsg.Id, (uint)VibratissimoBluetoothInfo.Chrs.TxSpeed, data);
+            return await Interface.WriteValue(aMsg.Id,
+                Info.Characteristics[(uint)VibratissimoBluetoothInfo.Chrs.TxSpeed],
+                data);
         }
     }
 }

--- a/Buttplug.Server/Bluetooth/Devices/VorzeA10Cyclone.cs
+++ b/Buttplug.Server/Bluetooth/Devices/VorzeA10Cyclone.cs
@@ -25,18 +25,19 @@ namespace Buttplug.Server.Bluetooth.Devices
         public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
             IBluetoothDeviceInterface aInterface)
         {
-            return new VorzeA10Cyclone(aLogManager,
-                aInterface);
+            return new VorzeA10Cyclone(aLogManager, aInterface, this);
         }
     }
 
     internal class VorzeA10Cyclone : ButtplugBluetoothDevice
     {
         public VorzeA10Cyclone(IButtplugLogManager aLogManager,
-            IBluetoothDeviceInterface aInterface)
+                               IBluetoothDeviceInterface aInterface,
+                               IBluetoothDeviceInfo aInfo)
             : base(aLogManager,
                    "Vorze A10 Cyclone",
-                   aInterface)
+                   aInterface,
+                   aInfo)
         {
             MsgFuncs.Add(typeof(VorzeA10CycloneCmd), HandleVorzeA10CycloneCmd);
             MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
@@ -58,7 +59,7 @@ namespace Buttplug.Server.Bluetooth.Devices
 
             var rawSpeed = (byte)(((byte)(cmdMsg.Clockwise ? 1 : 0)) << 7 | (byte)cmdMsg.Speed);
             return await Interface.WriteValue(aMsg.Id,
-                (uint)VorzeA10CycloneInfo.Chrs.Tx,
+                Info.Characteristics[(uint)VorzeA10CycloneInfo.Chrs.Tx],
                 new byte[] { 0x01, 0x01, rawSpeed });
         }
     }

--- a/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
+++ b/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Buttplug.Core;
+using Buttplug.Core.Messages;
+
+namespace Buttplug.Server.Bluetooth.Devices
+{
+    internal class WeVibeBluetoothInfo : IBluetoothDeviceInfo
+    {
+        public enum Chrs : uint
+        {
+            Tx = 0,
+            Rx,
+        }
+
+        public Guid[] Services { get; } = { new Guid("f000bb03-0451-4000-b000-000000000000") };
+
+        public string[] Names { get; } =
+        {
+            "Pivot",
+            "Verge",
+        };
+
+        public Guid[] Characteristics { get; } =
+        {
+            // tx characteristic
+            new Guid("f000c000-0451-4000-b000-000000000000"),
+
+            // rx characteristic
+            new Guid("f000b000-0451-4000-b000-000000000000"),
+        };
+
+        public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
+            IBluetoothDeviceInterface aInterface)
+        {
+            return new WeVibe(aLogManager,
+                aInterface);
+        }
+    }
+
+    internal class WeVibe : ButtplugBluetoothDevice
+    {
+        public WeVibe(IButtplugLogManager aLogManager,
+                       IBluetoothDeviceInterface aInterface)
+            : base(aLogManager,
+                   $"WeVibe Device ({aInterface.Name})",
+                   aInterface)
+        {
+            MsgFuncs.Add(typeof(SingleMotorVibrateCmd), HandleSingleMotorVibrateCmd);
+            MsgFuncs.Add(typeof(StopDeviceCmd), HandleStopDeviceCmd);
+        }
+
+        private async Task<ButtplugMessage> HandleStopDeviceCmd(ButtplugDeviceMessage aMsg)
+        {
+            return await HandleSingleMotorVibrateCmd(new SingleMotorVibrateCmd(aMsg.DeviceIndex, 0, aMsg.Id));
+        }
+
+        private async Task<ButtplugMessage> HandleSingleMotorVibrateCmd(ButtplugDeviceMessage aMsg)
+        {
+            var cmdMsg = aMsg as SingleMotorVibrateCmd;
+            if (cmdMsg is null)
+            {
+                return BpLogger.LogErrorMsg(aMsg.Id, Error.ErrorClass.ERROR_DEVICE, "Wrong Handler");
+            }
+
+            var rSpeed = Convert.ToUInt16(cmdMsg.Speed * 15);
+
+            // 0f 03 00 bc 00 00 00 00
+            var data = new byte[] { 0x0f, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            data[3] = Convert.ToByte(rSpeed); // External
+            data[3] |= Convert.ToByte(rSpeed << 4); // Internal
+
+            if (rSpeed == 0)
+            {
+                data[1] = 0x00;
+            }
+
+            Console.Out.WriteLine(BitConverter.ToString(data));
+            return await Interface.WriteValue(aMsg.Id, (uint)WeVibeBluetoothInfo.Chrs.Tx, data);
+        }
+    }
+}

--- a/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
+++ b/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
@@ -8,7 +8,7 @@ namespace Buttplug.Server.Bluetooth
     {
         string Name { get; }
 
-        Task<ButtplugMessage> WriteValue(uint aMsgId, uint aCharacteristicIndex, byte[] aValue, bool aWriteWithResponse = false);
+        Task<ButtplugMessage> WriteValue(uint aMsgId, Guid aCharacteristicIndex, byte[] aValue, bool aWriteWithResponse = false);
 
         ulong GetAddress();
 

--- a/Buttplug.Server/Buttplug.Server.csproj
+++ b/Buttplug.Server/Buttplug.Server.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Bluetooth\ButtplugBluetoothDevice.cs" />
     <Compile Include="Bluetooth\Devices\FleshlightLaunch.cs" />
     <Compile Include="Bluetooth\Devices\Kiiroo.cs" />
+    <Compile Include="Bluetooth\Devices\WeVibe.cs" />
     <Compile Include="Bluetooth\Devices\MagicMotion.cs" />
     <Compile Include="Bluetooth\Devices\Vibratissimo.cs" />
     <Compile Include="Bluetooth\Devices\Lovense.cs" />


### PR DESCRIPTION
This adds support for the WeVibe Pivot and Verge (and I'm pretty sure it just needs the names of the other devices in the WeVibe family to get them supported too).

The order of the GATT characteristics appeared to differ depending on whether I was using gatt-tool or the UWP interface, so as a side effect this fixes #108

Partial fix for #225 