### PR TITLE
feat: Add more WeVibe product names

### DIFF
--- a/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
+++ b/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
@@ -20,6 +20,8 @@ namespace Buttplug.Server.Bluetooth.Devices
         {
             "Pivot",
             "Verge",
+            "Nova",
+            "4 Plus"
         };
 
         public Guid[] Characteristics { get; } =


### PR DESCRIPTION
The 4 Plus works with the current code, assuming the Nova does too.