### PR TITLE
Making devices that disappear, reappear with the same ID

### DIFF
--- a/Buttplug.Core/ButtplugDevice.cs
+++ b/Buttplug.Core/ButtplugDevice.cs
@@ -13,6 +13,8 @@ namespace Buttplug.Core
 
         public string Identifier { get; }
 
+        public bool IsConnected { get { return !_isDisconnected; } }
+
         [CanBeNull]
         public event EventHandler DeviceRemoved;
 

--- a/Buttplug.Core/IButtplugDevice.cs
+++ b/Buttplug.Core/IButtplugDevice.cs
@@ -13,6 +13,9 @@ namespace Buttplug.Core
         [NotNull]
         string Identifier { get; }
 
+        [NotNull]
+        bool IsConnected { get; }
+
         [CanBeNull]
         event EventHandler DeviceRemoved;
 


### PR DESCRIPTION
For the Kiiroo ans XInput interfaces, the device list has been updated to leave the devices on the list, but with a (dissconnected) note next to them. If they reappear, they will continue to be used (assuming they are still selected).

Fixes #249