### PR TITLE
Making SSL the default operating mode for WebSockets

### DIFF
--- a/Buttplug.Apps.GameVibrationRouter.GUI/MainWindow.xaml
+++ b/Buttplug.Apps.GameVibrationRouter.GUI/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:Buttplug.Apps.GameVibrationRouter.GUI"
         xmlns:controls="clr-namespace:Buttplug.Components.Controls;assembly=Buttplug.Components.Controls"
         mc:Ignorable="d"
-        Title="Buttplug Game Vibration Router" Height="350" Width="525">
+        Title="Buttplug Game Vibration Router" Height="500" Width="600">
     <Grid>
         <controls:ButtplugTabControl Name="ButtplugTab"/>
     </Grid>

--- a/Buttplug.Apps.GameVibrationRouter.GUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.GameVibrationRouter.GUI/MainWindow.xaml.cs
@@ -58,6 +58,9 @@ namespace Buttplug.Apps.GameVibrationRouter.GUI
             ButtplugTab.SetApplicationTab("Processes", _processTab);
             ButtplugTab.AddDevicePanel(_bpServer);
             ButtplugTab.SelectedDevicesChanged += OnSelectedDevicesChanged;
+
+            var config = new ButtplugConfig("Buttplug");
+            ButtplugTab.GetAboutControl().CheckUpdate(config, "buttplug-csharp");
         }
 
         private void OnSelectedDevicesChanged(object aObj, List<ButtplugDeviceInfo> aDevices)

--- a/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml
+++ b/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:Buttplug.Components.Controls;assembly=Buttplug.Components.Controls"
         mc:Ignorable="d"
-        Title="Buttplug" Height="400" Width="600">
+        Title="Buttplug" Height="500" Width="600">
     <Grid>
         <controls:ButtplugTabControl Name="ButtplugTab"/>
     </Grid>

--- a/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
@@ -57,6 +57,9 @@ namespace Buttplug.Apps.KiirooEmulatorGUI
             StartServer();
             emu.ServerStatusChanged += OnServerStatusChanged;
             ButtplugTab.SelectedDevicesChanged += SelectionChangedHandler;
+
+            var config = new ButtplugConfig("Buttplug");
+            ButtplugTab.GetAboutControl().CheckUpdate(config, "buttplug-csharp");
         }
 
         private void OnServerStatusChanged(object aObj, bool aIsRunning)

--- a/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Windows;
 using System.Windows.Threading;
 using Buttplug.Components.Controls;
@@ -10,7 +11,6 @@ using Buttplug.Components.KiirooPlatformEmulator;
 using Buttplug.Core.Messages;
 using Buttplug.Server;
 using JetBrains.Annotations;
-using System.Threading;
 
 namespace Buttplug.Apps.KiirooEmulatorGUI
 {

--- a/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using Buttplug.Components.KiirooPlatformEmulator;
 using Buttplug.Core.Messages;
 using Buttplug.Server;
 using JetBrains.Annotations;
+using System.Threading;
 
 namespace Buttplug.Apps.KiirooEmulatorGUI
 {
@@ -97,7 +98,7 @@ namespace Buttplug.Apps.KiirooEmulatorGUI
             switch (aEvent.ExceptionObject)
             {
                 case HttpListenerException hle:
-                    MessageBox.Show(hle.Message, "Error Encountered", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                    new Thread(() => MessageBox.Show(hle.Message, "Error Encountered", MessageBoxButton.OK, MessageBoxImage.Exclamation)).Start();
                     StopServer();
                     if (hle.ErrorCode != 183)
                     {

--- a/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
+++ b/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
@@ -59,6 +59,10 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
+    <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
+++ b/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
@@ -72,7 +72,6 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
-    <Compile Include="ButtplugConfig.cs" />
     <Compile Include="WebsocketServerControl.xaml.cs">
       <DependentUpon>WebsocketServerControl.xaml</DependentUpon>
     </Compile>

--- a/Buttplug.Apps.WebsocketServerGUI/MainWindow.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:Buttplug.Components.Controls;assembly=Buttplug.Components.Controls"
         mc:Ignorable="d"
-        Title="MainWindow" Height="350" Width="525">
+        Title="MainWindow" Height="500" Width="600">
     <Grid>
         <controls:ButtplugTabControl Name="ButtplugTab"/>
     </Grid>

--- a/Buttplug.Apps.WebsocketServerGUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Buttplug.Components.Controls;
 
 namespace Buttplug.Apps.WebsocketServerGUI
 {
@@ -28,6 +29,8 @@ namespace Buttplug.Apps.WebsocketServerGUI
             ButtplugTab.SetServerDetails("Websocket Server", ping);
             _wsTab = new WebsocketServerControl(ButtplugTab);
             ButtplugTab.SetApplicationTab("Websocket Server", _wsTab);
+
+            ButtplugTab.GetAboutControl().CheckUpdate(config, "buttplug-csharp");
             Closing += ClosingHandler;
             _wsTab.StartServer();
         }

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
@@ -22,6 +22,7 @@
 					<RowDefinition Height="auto"/>
 					<RowDefinition Height="auto"/>
 					<RowDefinition Height="auto"/>
+					<RowDefinition Height="auto"/>
 				</Grid.RowDefinitions>
 				<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top"/>
 				<ListView Name="ConnectionUrl" Grid.Row="0" Height="auto" Margin="60,0,0,0" VerticalAlignment="Top" HorizontalContentAlignment="Stretch">
@@ -44,6 +45,9 @@
 				<Label Content="Status:"  Grid.Row="2" HorizontalAlignment="Left" Margin="0,5,0,0" VerticalAlignment="Top"/>
 				<Label Name="ConnStatus" Content="(Not Connected)" Grid.Row="2" HorizontalAlignment="Left" Margin="60,5,0,0" VerticalAlignment="Top"/>
 				<Button Name="DisconnectButton"  Height="25" Grid.Row="2" Content="Disconnect" IsEnabled="False" HorizontalAlignment="Right" Margin="0,5,0,0" VerticalAlignment="Top" Width="75" Click="DisconnectButton_Click"/>
+
+				<Label Content="Last Error:"  Grid.Row="3" HorizontalAlignment="Left" Margin="0,5,0,0" VerticalAlignment="Top"/>
+				<TextBlock Name="LastError" Text="" Grid.Row="3" HorizontalAlignment="Left" Margin="65,10,0,0" VerticalAlignment="Top" TextWrapping="Wrap"/>
 			</Grid>
 		</GroupBox>
 

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
@@ -5,51 +5,53 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
             d:DesignHeight="400" d:DesignWidth="600">
-	<Grid Background="#FFE5E5E5" >
-		<Grid.RowDefinitions>
-			<RowDefinition Height="45"/>
-			<RowDefinition Height="25"/>
-			<RowDefinition Height="auto"/>
-		</Grid.RowDefinitions>
-		<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
-		<TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" LostFocus="PortTextBox_LostFocus"/>
-		<CheckBox Name="SecureCheckBox"  Grid.Row="0" Content="SSL/TLS" HorizontalAlignment="Right" Margin="0,17,10,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
-		<CheckBox Name="LoopbackCheckBox"  Grid.Row="0" Content="Localhost Only" HorizontalAlignment="Right" Margin="0,17,90,0" VerticalAlignment="Top" Unchecked="LoopbackCheckBox_Unchecked" Checked="LoopbackCheckBox_Checked"/>
-		<Button Name="ConnToggleButton"  Grid.Row="1" Content="Start" HorizontalAlignment="Right" Margin="0,0,10,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
-		<GroupBox Header="Connection Details" Grid.Row="2" Margin="10,0" Padding="10,10,10,10" VerticalAlignment="Top" x:Name="ConnInfo">
-			<Grid Background="#FFE5E5E5" >
-				<Grid.RowDefinitions>
-					<RowDefinition Height="auto"/>
-					<RowDefinition Height="auto"/>
-					<RowDefinition Height="auto"/>
-					<RowDefinition Height="auto"/>
-				</Grid.RowDefinitions>
-				<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top"/>
-				<ListView Name="ConnectionUrl" Grid.Row="0" Height="auto" Margin="60,0,0,0" VerticalAlignment="Top" HorizontalContentAlignment="Stretch">
-					<ListView.ItemTemplate>
-						<DataTemplate>
-							<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" />
-									<ColumnDefinition Width="auto" />
-									<ColumnDefinition Width="auto" />
-								</Grid.ColumnDefinitions>
-								<TextBlock Name="WsUrl" Text="{Binding}" VerticalAlignment="Center" Grid.Column="0"/>
-								<Button Name="ConnItemCopy" Content="Copy" VerticalAlignment="Center" Grid.Column="1" Width="40" Click="ConnItemCopy_Click" Margin="0,0,5,0"/>
-								<Button Name="ConnItemTest" Content="Test" VerticalAlignment="Center" Grid.Column="2" Width="40" Click="ConnItemTest_Click"/>
-							</Grid>
-						</DataTemplate>
-					</ListView.ItemTemplate>
-				</ListView>
+	<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+		<Grid Background="#FFE5E5E5">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="45"/>
+				<RowDefinition Height="25"/>
+				<RowDefinition Height="auto"/>
+			</Grid.RowDefinitions>
+			<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
+			<TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" LostFocus="PortTextBox_LostFocus"/>
+			<CheckBox Name="SecureCheckBox"  Grid.Row="0" Content="SSL/TLS" HorizontalAlignment="Right" Margin="0,17,10,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
+			<CheckBox Name="LoopbackCheckBox"  Grid.Row="0" Content="Localhost Only" HorizontalAlignment="Right" Margin="0,17,90,0" VerticalAlignment="Top" Unchecked="LoopbackCheckBox_Unchecked" Checked="LoopbackCheckBox_Checked"/>
+			<Button Name="ConnToggleButton"  Grid.Row="1" Content="Start" HorizontalAlignment="Right" Margin="0,0,10,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
+			<GroupBox Header="Connection Details" Grid.Row="2" Margin="10,0" Padding="10,10,10,10" VerticalAlignment="Top" x:Name="ConnInfo">
+				<Grid Background="#FFE5E5E5" >
+					<Grid.RowDefinitions>
+						<RowDefinition Height="auto"/>
+						<RowDefinition Height="auto"/>
+						<RowDefinition Height="auto"/>
+						<RowDefinition Height="auto"/>
+					</Grid.RowDefinitions>
+					<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top"/>
+					<ListView Name="ConnectionUrl" Grid.Row="0" Height="auto" Margin="60,0,0,0" VerticalAlignment="Top" HorizontalContentAlignment="Stretch">
+						<ListView.ItemTemplate>
+							<DataTemplate>
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="auto" />
+										<ColumnDefinition Width="auto" />
+									</Grid.ColumnDefinitions>
+									<TextBlock Name="WsUrl" Text="{Binding}" VerticalAlignment="Center" Grid.Column="0"/>
+									<Button Name="ConnItemCopy" Content="Copy" VerticalAlignment="Center" Grid.Column="1" Width="40" Click="ConnItemCopy_Click" Margin="0,0,5,0"/>
+									<Button Name="ConnItemTest" Content="Test" VerticalAlignment="Center" Grid.Column="2" Width="40" Click="ConnItemTest_Click"/>
+								</Grid>
+							</DataTemplate>
+						</ListView.ItemTemplate>
+					</ListView>
 
-				<Label Content="Status:"  Grid.Row="2" HorizontalAlignment="Left" Margin="0,5,0,0" VerticalAlignment="Top"/>
-				<Label Name="ConnStatus" Content="(Not Connected)" Grid.Row="2" HorizontalAlignment="Left" Margin="60,5,0,0" VerticalAlignment="Top"/>
-				<Button Name="DisconnectButton"  Height="25" Grid.Row="2" Content="Disconnect" IsEnabled="False" HorizontalAlignment="Right" Margin="0,5,0,0" VerticalAlignment="Top" Width="75" Click="DisconnectButton_Click"/>
+					<Label Content="Status:"  Grid.Row="2" HorizontalAlignment="Left" Margin="0,5,0,0" VerticalAlignment="Top"/>
+					<Label Name="ConnStatus" Content="(Not Connected)" Grid.Row="2" HorizontalAlignment="Left" Margin="60,5,0,0" VerticalAlignment="Top"/>
+					<Button Name="DisconnectButton"  Height="25" Grid.Row="2" Content="Disconnect" IsEnabled="False" HorizontalAlignment="Right" Margin="0,5,0,0" VerticalAlignment="Top" Width="75" Click="DisconnectButton_Click"/>
 
-				<Label Content="Last Error:"  Grid.Row="3" HorizontalAlignment="Left" Margin="0,5,0,0" VerticalAlignment="Top"/>
-				<TextBlock Name="LastError" Text="" Grid.Row="3" HorizontalAlignment="Left" Margin="65,10,0,0" VerticalAlignment="Top" TextWrapping="Wrap"/>
-			</Grid>
-		</GroupBox>
+					<Label Content="Last Error:"  Grid.Row="3" HorizontalAlignment="Left" Margin="0,5,0,0" VerticalAlignment="Top"/>
+					<TextBlock Name="LastError" Text="" Grid.Row="3" HorizontalAlignment="Left" Margin="65,10,0,0" VerticalAlignment="Top" TextWrapping="Wrap"/>
+				</Grid>
+			</GroupBox>
 
-	</Grid>
+		</Grid>
+	</ScrollViewer>
 </UserControl>

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
@@ -12,7 +12,7 @@
 			<RowDefinition Height="auto"/>
 		</Grid.RowDefinitions>
 		<Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
-		<TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" TextChanged="PortTextBox_TextChanged"/>
+		<TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" LostFocus="PortTextBox_LostFocus"/>
 		<CheckBox Name="SecureCheckBox"  Grid.Row="0" Content="SSL/TLS" HorizontalAlignment="Right" Margin="0,17,10,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
 		<CheckBox Name="LoopbackCheckBox"  Grid.Row="0" Content="Localhost Only" HorizontalAlignment="Right" Margin="0,17,90,0" VerticalAlignment="Top" Unchecked="LoopbackCheckBox_Unchecked" Checked="LoopbackCheckBox_Checked"/>
 		<Button Name="ConnToggleButton"  Grid.Row="1" Content="Start" HorizontalAlignment="Right" Margin="0,0,10,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -195,7 +195,7 @@ namespace Buttplug.Apps.WebsocketServerGUI
             }
         }
 
-        private void PortTextBox_TextChanged(object aObj, TextChangedEventArgs aEvent)
+        private void PortTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
             if (uint.TryParse(PortTextBox.Text, out uint port) && port >= 1024 && port <= 65535)
             {
@@ -240,8 +240,17 @@ namespace Buttplug.Apps.WebsocketServerGUI
         {
             if (sender is Button)
             {
-                var data = (sender as Button).DataContext as ConnUrlData;
-                Clipboard.SetText(data.WsUrl);
+                try
+                {
+                    var data = (sender as Button).DataContext as ConnUrlData;
+                    Clipboard.SetText(data.WsUrl);
+                }
+                catch (Exception ex)
+                {
+                    // We've seen weird instances of can't open clipboard
+                    // but it's pretty rare. Log it.
+                    _log.LogException(ex);
+                }
             }
         }
 

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -11,6 +11,7 @@ using Buttplug.Server;
 using JetBrains.Annotations;
 using Microsoft.Win32;
 using Windows.UI.Notifications;
+using Buttplug.Components.Controls;
 
 namespace Buttplug.Apps.WebsocketServerGUI
 {

--- a/Buttplug.Components.Controls/Buttplug.Components.Controls.csproj
+++ b/Buttplug.Components.Controls/Buttplug.Components.Controls.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ButtplugAboutControl.xaml.cs">
       <DependentUpon>ButtplugAboutControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ButtplugConfig.cs" />
     <Compile Include="ButtplugDeviceControl.xaml.cs">
       <DependentUpon>ButtplugDeviceControl.xaml</DependentUpon>
     </Compile>

--- a/Buttplug.Components.Controls/ButtplugAboutControl.xaml
+++ b/Buttplug.Components.Controls/ButtplugAboutControl.xaml
@@ -4,10 +4,19 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="525">
-        <Grid Background="#FFE5E5E5">
-		<Image Name="IconImage" Source="pack://application:,,,/Buttplug.Components.Controls;component/Resources/buttplug-logo-1.png" HorizontalAlignment="Left" Height="128" Margin="10,10,0,0" VerticalAlignment="Top" Width="128" MouseDown="IconImage_Click"/>
-		<TextBlock HorizontalAlignment="Left" Margin="143,10,0,0" VerticalAlignment="Top" Height="auto" Width="360">
+             d:DesignHeight="400" d:DesignWidth="525">
+
+	<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+		<Grid Background="#FFE5E5E5">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="auto"/>
+				<RowDefinition Height="auto"/>
+				<RowDefinition Height="auto"/>
+				<RowDefinition Height="auto"/>
+			</Grid.RowDefinitions>
+
+			<Image Grid.Row="0" Name="IconImage" Source="pack://application:,,,/Buttplug.Components.Controls;component/Resources/buttplug-logo-1.png" HorizontalAlignment="Left" Height="128" Margin="10,10,0,0" VerticalAlignment="Top" Width="128" MouseDown="IconImage_Click"/>
+			<TextBlock Grid.Row="0" HorizontalAlignment="Left" Margin="150,0,0,0" VerticalAlignment="Top" Height="auto" Width="auto">
                 <Span FontSize="19" FontWeight="Bold">Buttplug <Run Name="AboutVersionNumber">1.0.0.0-branch</Run> (C# Edition)</Span><LineBreak />
                 <Run Name="AboutGitVersion" Cursor="Hand">0123456789abcdef0123456789abcdef01234567</Run><LineBreak />
                 By <Hyperlink NavigateUri="https://metafetish.com" RequestNavigate="Hyperlink_RequestNavigate">Metafetish</Hyperlink><LineBreak />
@@ -16,8 +25,27 @@
                 Documentation at <Hyperlink NavigateUri="https://buttplug.io/docs" RequestNavigate="Hyperlink_RequestNavigate">https://buttplug.io/docs</Hyperlink><LineBreak/>
                 Source code at <Hyperlink NavigateUri="https://github.com/metafetish" RequestNavigate="Hyperlink_RequestNavigate">https://github.com/metafetish</Hyperlink><LineBreak/>
                 License information <Hyperlink Click="LicenseHyperlink_Click" >here</Hyperlink><LineBreak/>
-            </TextBlock>
-        <TextBlock HorizontalAlignment="Left" Margin="7,152,0,0" TextWrapping="Wrap" VerticalAlignment="Top"><Run Text="Buttplug and the corresponding applications and libraries are provided open source and free of charge. If you would like to help sponsor further development of this and other adult toy and interface software, please consider donating to our patreon campaign at "/><Hyperlink NavigateUri="https://patreon.com/qdot"><Run Text="http://patreon.com/qdot"/></Hyperlink><Run Text=", or by clicking on the Patreon image below. Thanks, and enjoy buttplugging!"/></TextBlock>
-        <Image Source="pack://application:,,,/Buttplug.Components.Controls;component/Resources/buttplugin-with-qdot-intro-patreon-image.png"  HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="116" Height="65" Margin="0,10,0,10" MouseDown="PatreonRequestNavigate" />
-        </Grid>
+			</TextBlock>
+
+			<TextBlock Grid.Row="1" HorizontalAlignment="Left" Margin="10,0,0,0" TextWrapping="Wrap" VerticalAlignment="Top"><Run Text="Buttplug and the corresponding applications and libraries are provided open source and free of charge. If you would like to help sponsor further development of this and other adult toy and interface software, please consider donating to our patreon campaign at "/><Hyperlink NavigateUri="https://patreon.com/qdot"><Run Text="http://patreon.com/qdot"/></Hyperlink><Run Text=", or by clicking on the Patreon image below. Thanks, and enjoy buttplugging!"/></TextBlock>
+			<Image Grid.Row="2" Source="pack://application:,,,/Buttplug.Components.Controls;component/Resources/buttplugin-with-qdot-intro-patreon-image.png"  HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="116" Height="65" Margin="0,10,0,10" MouseDown="PatreonRequestNavigate" />
+
+			<GroupBox Grid.Row="3" Name="UpdateGroup" Height="auto" Padding="5" Margin="5" Header="Updates:" Visibility="Collapsed">
+				<Grid>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="auto"/>
+						<RowDefinition Height="auto"/>
+					</Grid.RowDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="auto"/>
+						<ColumnDefinition Width="*"/>
+					</Grid.ColumnDefinitions>
+					<CheckBox Grid.Row="0" Name="AutoUpdateCheck" Content="Check on startup" VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Checked="AutoUpdateCheck_Checked" Unchecked="AutoUpdateCheck_Unchecked"/>
+					<Button Grid.Row="0" Name="CheckForUpdates" Content="Check now" Width="auto" HorizontalAlignment="Left" Margin="0,0" Grid.Column="0" Click="CheckForUpdates_Click"/>
+					<Label Grid.Row="1" Content="Status:" Width="auto" HorizontalAlignment="Left" Margin="0,0" Grid.Column="0"/>
+					<TextBlock Grid.Row="1" Width="auto" Name="UpdateCheckStatus" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,0"  Grid.Column="1">No check performed</TextBlock>
+				</Grid>
+			</GroupBox>
+		</Grid>
+	</ScrollViewer>
 </UserControl>

--- a/Buttplug.Components.Controls/ButtplugAboutControl.xaml
+++ b/Buttplug.Components.Controls/ButtplugAboutControl.xaml
@@ -7,9 +7,9 @@
              d:DesignHeight="300" d:DesignWidth="525">
         <Grid Background="#FFE5E5E5">
 		<Image Name="IconImage" Source="pack://application:,,,/Buttplug.Components.Controls;component/Resources/buttplug-logo-1.png" HorizontalAlignment="Left" Height="128" Margin="10,10,0,0" VerticalAlignment="Top" Width="128" MouseDown="IconImage_Click"/>
-		<TextBlock HorizontalAlignment="Left" Margin="143,10,0,0" VerticalAlignment="Top" Height="128" Width="360">
+		<TextBlock HorizontalAlignment="Left" Margin="143,10,0,0" VerticalAlignment="Top" Height="auto" Width="360">
                 <Span FontSize="19" FontWeight="Bold">Buttplug <Run Name="AboutVersionNumber">1.0.0.0-branch</Run> (C# Edition)</Span><LineBreak />
-			<Span FontSize="19"><Run Name="AboutGitVersion">0123456789abcdef0123456789abcdef01234567</Run></Span><LineBreak />
+                <Run Name="AboutGitVersion" Cursor="Hand">0123456789abcdef0123456789abcdef01234567</Run><LineBreak />
                 By <Hyperlink NavigateUri="https://metafetish.com" RequestNavigate="Hyperlink_RequestNavigate">Metafetish</Hyperlink><LineBreak />
                 <LineBreak/>
                 Software updates at <Hyperlink NavigateUri="https://github.com/metafetish" RequestNavigate="Hyperlink_RequestNavigate">https://buttplug.io/</Hyperlink><LineBreak/>
@@ -17,7 +17,7 @@
                 Source code at <Hyperlink NavigateUri="https://github.com/metafetish" RequestNavigate="Hyperlink_RequestNavigate">https://github.com/metafetish</Hyperlink><LineBreak/>
                 License information <Hyperlink Click="LicenseHyperlink_Click" >here</Hyperlink><LineBreak/>
             </TextBlock>
-        <TextBlock HorizontalAlignment="Left" Margin="7,147,0,0" TextWrapping="Wrap" VerticalAlignment="Top"><Run Text="Buttplug and the corresponding applications and libraries are provided open source and free of charge. If you would like to help sponsor further development of this and other adult toy and interface software, please consider donating to our patreon campaign at "/><Hyperlink NavigateUri="https://patreon.com/qdot"><Run Text="http://patreon.com/qdot"/></Hyperlink><Run Text=", or by clicking on the Patreon image below. Thanks, and enjoy buttplugging!"/></TextBlock>
+        <TextBlock HorizontalAlignment="Left" Margin="7,152,0,0" TextWrapping="Wrap" VerticalAlignment="Top"><Run Text="Buttplug and the corresponding applications and libraries are provided open source and free of charge. If you would like to help sponsor further development of this and other adult toy and interface software, please consider donating to our patreon campaign at "/><Hyperlink NavigateUri="https://patreon.com/qdot"><Run Text="http://patreon.com/qdot"/></Hyperlink><Run Text=", or by clicking on the Patreon image below. Thanks, and enjoy buttplugging!"/></TextBlock>
         <Image Source="pack://application:,,,/Buttplug.Components.Controls;component/Resources/buttplugin-with-qdot-intro-patreon-image.png"  HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="116" Height="65" Margin="0,10,0,10" MouseDown="PatreonRequestNavigate" />
         </Grid>
 </UserControl>

--- a/Buttplug.Components.Controls/ButtplugAboutControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugAboutControl.xaml.cs
@@ -97,6 +97,12 @@ namespace Buttplug.Components.Controls
 
         public void CheckUpdate([NotNull] ButtplugConfig config, [NotNull] string appName)
         {
+            if (Application.Current == null)
+            {
+                // Avoid test harness
+                return;
+            }
+
             _config = config;
             _appName = appName;
 

--- a/Buttplug.Components.Controls/ButtplugAboutControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugAboutControl.xaml.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Input;
 using Buttplug.Core;
+using JetBrains.Annotations;
+using Newtonsoft.Json.Linq;
 
 namespace Buttplug.Components.Controls
 {
@@ -14,6 +20,8 @@ namespace Buttplug.Components.Controls
         private string _gitHash;
         private string _buildType;
         private uint _clickCounter;
+        private ButtplugConfig _config;
+        private string _appName;
 
         public event EventHandler AboutImageClickedABunch;
 
@@ -33,7 +41,6 @@ namespace Buttplug.Components.Controls
             }
 
             // AssemblyInformationalVersion("1.0.0.0-dev")
-
             var pos = longVer.IndexOf('-');
             if (pos > 0)
             {
@@ -86,6 +93,125 @@ namespace Buttplug.Components.Controls
         private void LicenseHyperlink_Click(object aSender, RoutedEventArgs aEvent)
         {
             new LicenseView().Show();
+        }
+
+        public void CheckUpdate([NotNull] ButtplugConfig config, [NotNull] string appName)
+        {
+            _config = config;
+            _appName = appName;
+
+            var check = _config.GetValue(appName + ".updateCheck");
+            if (check == null)
+            {
+                var result = MessageBox.Show("Do you want Buttplug to automaticaly check for updates on start?", "Update Checking", MessageBoxButton.YesNo);
+                check = result == MessageBoxResult.Yes ? "true" : "false";
+                _config.SetValue(appName + ".updateCheck", check);
+            }
+
+            AutoUpdateCheck.IsChecked = bool.Parse(check);
+            UpdateGroup.Visibility = Visibility.Visible;
+
+            if (!bool.Parse(check))
+            {
+                return;
+            }
+
+            CheckForUpdates_Click(this, null);
+        }
+
+        private void AutoUpdateCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            if (_config != null && _appName != null && _appName.Length > 0)
+            {
+                _config.SetValue(_appName + ".updateCheck", true.ToString());
+            }
+        }
+
+        private void AutoUpdateCheck_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (_config != null && _appName != null && _appName.Length > 0)
+            {
+                _config.SetValue(_appName + ".updateCheck", false.ToString());
+            }
+        }
+
+        private void CheckForUpdates_Click(object sender, RoutedEventArgs e)
+        {
+            if (_config == null || _appName == null || _appName.Length <= 0)
+            {
+                return;
+            }
+
+            UpdateCheckStatus.Inlines.Clear();
+            UpdateCheckStatus.Text = "Checking for updates... (" + DateTime.Now.ToString() + ")";
+
+            try
+            {
+                string html = string.Empty;
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create("https://updates.buttplug.io/updates.json");
+                request.AutomaticDecompression = DecompressionMethods.GZip;
+
+                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+                using (Stream stream = response.GetResponseStream())
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    html = reader.ReadToEnd();
+                }
+
+                var json = JObject.Parse(html);
+                var latest = json[_appName]["version"]?.ToString();
+                if (latest != null)
+                {
+                    var numericVer = AboutVersionNumber.Text.Substring(0, AboutVersionNumber.Text.IndexOf('-'));
+                    var cVer = Version.Parse(numericVer);
+                    var lVer = Version.Parse(latest);
+
+                    // Reverse this sign to test
+                    if (cVer.CompareTo(lVer) < 0)
+                    {
+                        // Update available
+                        UpdateCheckStatus.Text = "Update Available! (" + DateTime.Now.ToString() + ")";
+                        try
+                        {
+                            var location = json[_appName]["location"]?.ToString();
+                            if (location != null)
+                            {
+                                var hyperlink = new Hyperlink(new Run(location))
+                                {
+                                    NavigateUri = new Uri(location),
+                                };
+                                hyperlink.RequestNavigate += Hyperlink_RequestNavigate;
+                                UpdateCheckStatus.Text += "\n";
+                                UpdateCheckStatus.Inlines.Add(hyperlink);
+                            }
+                        }
+                        catch
+                        {
+                            // noop - there was an update, we just don't know where
+                        }
+
+                        MessageBox.Show("A new buttplug update is available!", "Buttplug Update");
+                        try
+                        {
+                            ((TabControl)((TabItem)Parent).Parent).SelectedItem = Parent;
+                            UpdateCheckStatus.Focus();
+                        }
+                        catch
+                        {
+                            // noop - things went bang
+                        }
+                    }
+                    else
+                    {
+                        UpdateCheckStatus.Text = "No new updates! (" + DateTime.Now.ToString() + ")";
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                UpdateCheckStatus.Text = "Error encountered whilst checking for updates! (" + DateTime.Now.ToString() + ")";
+                new ButtplugLogManager().GetLogger(GetType()).LogException(ex);
+            }
         }
     }
 }

--- a/Buttplug.Components.Controls/ButtplugConfig.cs
+++ b/Buttplug.Components.Controls/ButtplugConfig.cs
@@ -4,7 +4,7 @@ using System.IO;
 using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 
-namespace Buttplug.Apps.WebsocketServerGUI
+namespace Buttplug.Components.Controls
 {
     public class ButtplugConfig
     {

--- a/Buttplug.Components.Controls/ButtplugLogControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugLogControl.xaml.cs
@@ -8,11 +8,11 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Buttplug.Core;
 using Microsoft.Win32;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
-using Buttplug.Core;
 
 namespace Buttplug.Components.Controls
 {

--- a/Buttplug.Components.Controls/ButtplugLogControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugLogControl.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.Win32;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using Buttplug.Core;
 
 namespace Buttplug.Components.Controls
 {
@@ -166,8 +167,7 @@ namespace Buttplug.Components.Controls
                 return;
             }
 
-            if ((e.KeyboardDevice.IsKeyDown(Key.LeftCtrl) || e.KeyboardDevice.IsKeyDown(Key.RightCtrl))
-                && e.Key == Key.C)
+            if (e.KeyboardDevice.Modifiers == ModifierKeys.Control && e.Key == Key.C)
             {
                 var builder = new StringBuilder();
                 foreach (var item in LogListBox.SelectedItems)
@@ -182,7 +182,18 @@ namespace Buttplug.Components.Controls
                     }
                 }
 
-                Clipboard.SetText(builder.ToString());
+                try
+                {
+                    Clipboard.SetText(builder.ToString());
+                }
+                catch (Exception ex)
+                {
+                    // We've seen weird instances of can't open clipboard
+                    // but it's pretty rare. Log it.
+                    var logMan = new ButtplugLogManager();
+                    var log = logMan.GetLogger(GetType());
+                    log.LogException(ex);
+                }
             }
         }
     }

--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml
@@ -6,24 +6,24 @@
              xmlns:local="clr-namespace:Buttplug.Components.Controls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <TabControl Margin="0,0,-0.333,-0.333">           
-            <TabItem Header="Application" Name="ApplicationTab"/>
-            <TabItem Header="Devices" Name="DevicesTab">
-                <local:ButtplugDeviceControl x:Name="DeviceControl" />
-            </TabItem>
-            <TabItem Header="Logs">
-                <local:ButtplugLogControl x:Name="LogControl" />
-            </TabItem>
-            <TabItem Header="About">
-                <local:ButtplugAboutControl x:Name="AboutControl" />
-            </TabItem>
-            <TabItem Name="DeveloperTab" Header="Developer" Visibility="Hidden">
-                <Grid Background="#FFE5E5E5">
-                    <Button Content="Crash Application" Margin="10,10,0,232" HorizontalAlignment="Left" Click="CrashButton_Click" Width="108" Height="30"/>
-                    <Button Content="Send Logs" Margin="10,56,0,186" HorizontalAlignment="Left" Click="SendLogsButton_Click" Width="108" Height="30"/>
-                </Grid>
-            </TabItem>
-        </TabControl>
-    </Grid>
+	<Grid>
+		<TabControl Margin="0,0,-0.333,-0.333">
+			<TabItem Header="Application" Name="ApplicationTab"/>
+			<TabItem Header="Devices" Name="DevicesTab">
+				<local:ButtplugDeviceControl x:Name="DeviceControl" />
+			</TabItem>
+			<TabItem Header="Logs">
+				<local:ButtplugLogControl x:Name="LogControl" />
+			</TabItem>
+			<TabItem Header="About"  Name="AboutTab">
+				<local:ButtplugAboutControl x:Name="AboutControl" ScrollViewer.CanContentScroll="True" />
+			</TabItem>
+			<TabItem Name="DeveloperTab" Header="Developer" Visibility="Collapsed">
+				<Grid Background="#FFE5E5E5">
+					<Button Content="Crash Application" Margin="10,10,0,232" HorizontalAlignment="Left" Click="CrashButton_Click" Width="108" Height="30"/>
+					<Button Content="Send Logs" Margin="10,56,0,186" HorizontalAlignment="Left" Click="SendLogsButton_Click" Width="108" Height="30"/>
+				</Grid>
+			</TabItem>
+		</TabControl>
+	</Grid>
 </UserControl>

--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
@@ -82,7 +82,7 @@ namespace Buttplug.Components.Controls
             }
 
             AboutControl.AboutImageClickedABunch += (aObj, aEvent) => DeveloperTab.Visibility = Visibility.Visible;
-            DevicesTab.Visibility = Visibility.Hidden;
+            DevicesTab.Visibility = Visibility.Collapsed;
             DeviceControl.DeviceSelectionChanged += OnSelectedDevicesChanged;
         }
 

--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
@@ -217,6 +217,11 @@ namespace Buttplug.Components.Controls
             return LogControl;
         }
 
+        public ButtplugAboutControl GetAboutControl()
+        {
+            return AboutControl;
+        }
+
         public void SetServerDetails(string serverName, uint maxPingTime)
         {
             _serverName = serverName;

--- a/Buttplug.Components.KiirooPlatformEmulator/KiirooPlatformEmulator.cs
+++ b/Buttplug.Components.KiirooPlatformEmulator/KiirooPlatformEmulator.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 using System.Web;
+using Buttplug.Core;
 using JetBrains.Annotations;
 
 namespace Buttplug.Components.KiirooPlatformEmulator
@@ -24,6 +25,7 @@ namespace Buttplug.Components.KiirooPlatformEmulator
         private readonly HttpListener _httpListener;
         private bool _stop;
         private bool _isRunning;
+        private IButtplugLog _log;
 
         public event EventHandler<KiirooPlatformEventArgs> OnKiirooPlatformEvent;
 
@@ -31,6 +33,7 @@ namespace Buttplug.Components.KiirooPlatformEmulator
 
         public KiirooPlatformEmulator()
         {
+            _log = new ButtplugLogManager().GetLogger(GetType());
             _httpListener = new HttpListener();
             _httpListener.Prefixes.Add("http://localhost:6969/");
             _stop = false;
@@ -75,6 +78,7 @@ namespace Buttplug.Components.KiirooPlatformEmulator
             }
             catch (Exception e)
             {
+                _log.LogException(e);
                 OnException?.Invoke(this, new UnhandledExceptionEventArgs(e, true));
                 _isRunning = false;
                 return;
@@ -89,12 +93,18 @@ namespace Buttplug.Components.KiirooPlatformEmulator
                 }
                 catch (HttpListenerException ex)
                 {
+                    _log.LogException(ex);
                     if (ex.ErrorCode == 995)
                     {
                         StopServer();
                         _isRunning = false;
                         return;
                     }
+                }
+                catch (Exception e)
+                {
+                    _log.LogException(e);
+                    OnException?.Invoke(this, new UnhandledExceptionEventArgs(e, true));
                 }
 
                 if (ctx == null)

--- a/Buttplug.Core/Buttplug.Core.csproj
+++ b/Buttplug.Core/Buttplug.Core.csproj
@@ -70,6 +70,7 @@
     <Compile Include="IButtplugDevice.cs" />
     <Compile Include="IButtplugLog.cs" />
     <Compile Include="IButtplugLogManager.cs" />
+    <Compile Include="LogExceptionEventArgs.cs" />
     <Compile Include="MessageReceivedEventArgs.cs" />
     <Compile Include="ButtplugDevice.cs" />
     <Compile Include="Messages\Messages.cs" />

--- a/Buttplug.Core/ButtplugLog.cs
+++ b/Buttplug.Core/ButtplugLog.cs
@@ -84,9 +84,12 @@ namespace Buttplug.Core
             return new Error(aMsg, aCode, aId);
         }
 
-        public void LogException(Exception aEx, bool aLocalOnly = true)
+        public event EventHandler<LogExceptionEventArgs> OnLogException;
+
+        public void LogException(Exception aEx, bool aLocalOnly = true, string aMsg = null)
         {
-            Error(aEx.GetType().ToString() + ": " + aEx.Message + "\n" + aEx.StackTrace, aLocalOnly);
+            Error((aEx?.GetType().ToString() ?? "Unknown Exception") + ": " + aMsg ?? (aEx.Message + "\n" + aEx.StackTrace), aLocalOnly);
+            OnLogException?.Invoke(this, new LogExceptionEventArgs(aEx, aLocalOnly, aMsg));
         }
     }
 }

--- a/Buttplug.Core/IButtplugLog.cs
+++ b/Buttplug.Core/IButtplugLog.cs
@@ -21,7 +21,10 @@ namespace Buttplug.Core
         // ReSharper disable once UnusedMember.Global
         void Fatal(string aMsg, bool aLocalOnly = false);
 
-        void LogException(Exception aMsg, bool aLocalOnly = true);
+        void LogException(Exception aEx, bool aLocalOnly = true, string aMsg = null);
+
+        [CanBeNull]
+        event EventHandler<LogExceptionEventArgs> OnLogException;
 
         [NotNull]
         Error LogErrorMsg(uint aId, ErrorClass aCode, string aMsg);

--- a/Buttplug.Core/LogExceptionEventArgs.cs
+++ b/Buttplug.Core/LogExceptionEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Buttplug.Core
+{
+    public class LogExceptionEventArgs : EventArgs
+    {
+        public LogExceptionEventArgs(Exception aEx, bool aLocalOnly, string aErrorMessage)
+        {
+            ErrorMessage = aErrorMessage;
+            Ex = aEx;
+            LocalOnly = aLocalOnly;
+        }
+
+        public string ErrorMessage { get; }
+
+        public Exception Ex { get; }
+
+        public bool LocalOnly { get; }
+    }
+}


### PR DESCRIPTION
This change also includes better error reporting: the last error is displayed on the WebSocket tab and notifications of errors are raised via the Windows Toast system.

Additionally, the gap in the tabs left by the Devices tab has been fixed.