### PR TITLE
Suppressing websocket exceptions that don't close the connections

### DIFF
--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -77,15 +77,20 @@ namespace Buttplug.Apps.WebsocketServerGUI
         private void WebSocketExceptionHandler(object aObj, [NotNull] UnhandledExceptionEventArgs aEx)
         {
             var errorMessage = (aEx.ExceptionObject as Exception)?.Message ?? "Unknown";
-            if (_secure &&
-                (errorMessage.Contains("An established connection was aborted by the software in your host machine") ||
-                 errorMessage.Contains("Not GET request")))
+
+            if (_secure && errorMessage.Contains("Not GET request") && _ws != null && !aEx.IsTerminating)
             {
-                errorMessage += "\n\nThis usually means that the client/browser has not accepted our SSL certificate. Try hitting the test button on the \"Websocket Server\" tab.";
+                _log.LogException(aEx.ExceptionObject as Exception, true, errorMessage);
+                return;
             }
-            else if (_secure && errorMessage.Contains("The handshake failed due to an unexpected packet format"))
+
+            if (_secure && errorMessage.Contains("The handshake failed due to an unexpected packet format"))
             {
                 errorMessage += "\n\nThis usually means that the client/browser tried to connect without SSL. Make sure the client is set use the wss:// URI scheme.";
+            }
+            else if (_secure)
+            {
+                errorMessage += "\n\nThis could mean that the client/browser has not accepted our SSL certificate. Try hitting the test button on the \"Websocket Server\" tab.";
             }
 
             _log.LogException(aEx.ExceptionObject as Exception, true, errorMessage);

--- a/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
+++ b/Buttplug.Components.WebsocketServer/ButtplugWebsocketServer.cs
@@ -44,6 +44,8 @@ namespace Buttplug.Components.WebsocketServer
         [NotNull]
         private CancellationTokenSource _cancellation;
 
+        public bool IsConnected => _server.IsStarted;
+
         public void StartServer([NotNull] IButtplugServerFactory aFactory, int aPort = 12345, bool aLoopBack = true, bool aSecure = false, string aHostname = "localhost")
         {
             _cancellation = new CancellationTokenSource();
@@ -71,9 +73,10 @@ namespace Buttplug.Components.WebsocketServer
         {
             while (!aToken.IsCancellationRequested)
             {
+                WebSocket ws = null;
                 try
                 {
-                    var ws = await aServer.AcceptWebSocketAsync(aToken).ConfigureAwait(false);
+                    ws = await aServer.AcceptWebSocketAsync(aToken).ConfigureAwait(false);
                     if (ws != null)
                     {
                         Task.Run(() => HandleConnectionAsync(ws, aToken));
@@ -81,7 +84,7 @@ namespace Buttplug.Components.WebsocketServer
                 }
                 catch (Exception aEx)
                 {
-                    OnException?.Invoke(this, new UnhandledExceptionEventArgs(aEx, false));
+                    OnException?.Invoke(this, new UnhandledExceptionEventArgs(aEx, !(ws?.IsConnected ?? false)));
                 }
             }
         }


### PR DESCRIPTION
This should quite down the "Not GET" notices.