### PR TITLE
Toast click handling and more Kiiroo exception handling

### DIFF
--- a/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
+++ b/Buttplug.Apps.KiirooEmulatorGUI/MainWindow.xaml.cs
@@ -111,6 +111,7 @@ namespace Buttplug.Apps.KiirooEmulatorGUI
                     break;
 
                 default:
+                    // There could be other exceptions thrown here, but we don't know what they all are yet.
                     throw aEvent.ExceptionObject as Exception;
             }
         }

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -129,6 +129,7 @@ namespace Buttplug.Apps.WebsocketServerGUI
                     toastXml.SelectSingleNode("//*[@id='1']").InnerText = "Buttplug Error";
                     toastXml.SelectSingleNode("//*[@id='2']").InnerText = aEvent.ErrorMessage;
                     var toast = new ToastNotification(toastXml);
+                    toast.Activated += OnActivatedToast;
                     var appId = (string)Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Classes\AppID\" + AppDomain.CurrentDomain.FriendlyName, "AppId", string.Empty);
                     if (appId != null && appId.Length > 0)
                     {
@@ -136,6 +137,11 @@ namespace Buttplug.Apps.WebsocketServerGUI
                     }
                 });
             }
+        }
+
+        private void OnActivatedToast(ToastNotification sender, object args)
+        {
+            Dispatcher.Invoke(() => { Window.GetWindow(this).Activate(); });
         }
 
         public void StartServer()

--- a/Buttplug.Components.KiirooPlatformEmulator/KiirooPlatformEmulator.cs
+++ b/Buttplug.Components.KiirooPlatformEmulator/KiirooPlatformEmulator.cs
@@ -101,6 +101,10 @@ namespace Buttplug.Components.KiirooPlatformEmulator
                         return;
                     }
                 }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
                 catch (Exception e)
                 {
                     _log.LogException(e);


### PR DESCRIPTION
Clicking the toast messages now raises the GUI to the front.
Disposed HttpListeners are now handled as closed connections.