### PR TITLE
fix: Only pop toaster if we haven't connected to websocket

### DIFF
--- a/Buttplug.Client/Buttplug.Client.nuspec
+++ b/Buttplug.Client/Buttplug.Client.nuspec
@@ -10,9 +10,8 @@
     <projectUrl>http://www.github.com/metafetish/buttplug-csharp</projectUrl>
     <iconUrl>https://github.com/metafetish/buttplug-csharp/blob/master/Buttplug.Components.Controls/Resources/buttplug-logo-1.png?raw=true</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Client Library for the Buttplug Sex Toy Control Protocol</description>
-    <releaseNotes>Prerelease package. Abandon all hope, ye who enter here.</releaseNotes>
-    <copyright>Copyright 2017 Metafetish</copyright>
+    <description>Client Library for the Buttplug Sex Toy Control Protocol. Contains client classes for library style (embedded) client/server setups, as well as a WebSocket client.</description>
+    <copyright>Copyright 2017 Nonpolynomial Labs, LLC</copyright>
     <dependencies>
       <dependency id="Buttplug.Core" version="0.0.0" />
     </dependencies>

--- a/Buttplug.Components.Controls/Buttplug.Components.Controls.nuspec
+++ b/Buttplug.Components.Controls/Buttplug.Components.Controls.nuspec
@@ -1,19 +1,20 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
-    <title>Buttplug Server Library</title>
+    <title>Buttplug Controls Library</title>
     <authors>qdot</authors>
     <owners>qdot</owners>
     <licenseUrl>https://opensource.org/licenses/BSD-3-Clause</licenseUrl>
     <projectUrl>http://www.github.com/metafetish/buttplug-csharp</projectUrl>
     <iconUrl>https://github.com/metafetish/buttplug-csharp/blob/master/Buttplug.Components.Controls/Resources/buttplug-logo-1.png?raw=true</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Base Server Library for the Buttplug Sex Toy Control Protocol. Manages device classes and connection states.</description>
+    <description>WPF Controls Library for the Buttplug Sex Toy Control Protocol Applications. Contains a main tab control, about control, and device control for rapid prototyping Buttplug based applications.</description>
     <copyright>Copyright 2017 Nonpolynomial Labs, LLC</copyright>
     <dependencies>
       <dependency id="Buttplug.Core" version="0.0.0" />
+      <dependency id="Buttplug.Server" version="0.0.0" />
     </dependencies>
   </metadata>
 </package>

--- a/Buttplug.Core/Buttplug.Core.nuspec
+++ b/Buttplug.Core/Buttplug.Core.nuspec
@@ -10,8 +10,7 @@
     <projectUrl>http://www.github.com/metafetish/buttplug-csharp</projectUrl>
     <iconUrl>https://github.com/metafetish/buttplug-csharp/blob/master/Buttplug.Components.Controls/Resources/buttplug-logo-1.png?raw=true</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Core Library for the Buttplug Sex Toy Control Protocol</description>
-    <releaseNotes>Prerelease package. Abandon all hope, ye who enter here.</releaseNotes>
-    <copyright>Copyright 2017 Metafetish</copyright>
+    <description>Core Library for the Buttplug Sex Toy Control Protocol. Contains base classes for message creation, abstract devices/transports, and utilities for Client/Server creation.</description>
+    <copyright>Copyright 2017 Nonpolynomial Labs, LLC</copyright>
   </metadata>
 </package>

--- a/Buttplug.Server.Managers.UWPBluetoothManager/Buttplug.Server.Managers.UWPBluetoothManager.nuspec
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/Buttplug.Server.Managers.UWPBluetoothManager.nuspec
@@ -11,8 +11,7 @@
     <iconUrl>https://github.com/metafetish/buttplug-csharp/blob/master/Buttplug.Components.Controls/Resources/buttplug-logo-1.png?raw=true</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Library for adding UWP Bluetooth (Windows 10 15063 Creators Update or Later) support to Buttplug Servers</description>
-    <releaseNotes>Prerelease package. Abandon all hope, ye who enter here.</releaseNotes>
-    <copyright>Copyright 2017 Metafetish</copyright>
+    <copyright>Copyright 2017 Nonpolynomial Labs, LLC</copyright>
     <dependencies>
       <dependency id="Buttplug.Core" version="0.0.0" />
       <dependency id="Buttplug.Server" version="0.0.0" />

--- a/Buttplug.Server.Managers.XInputGamepadManager/Buttplug.Server.Managers.XInputGamepadManager.nuspec
+++ b/Buttplug.Server.Managers.XInputGamepadManager/Buttplug.Server.Managers.XInputGamepadManager.nuspec
@@ -10,9 +10,8 @@
     <projectUrl>http://www.github.com/metafetish/buttplug-csharp</projectUrl>
     <iconUrl>https://github.com/metafetish/buttplug-csharp/blob/master/Buttplug.Components.Controls/Resources/buttplug-logo-1.png?raw=true</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Library for adding XInput Gamepad (Windows 7 or Later) support to Buttplug Servers</description>
-    <releaseNotes>Prerelease package. Abandon all hope, ye who enter here.</releaseNotes>
-    <copyright>Copyright 2017 Metafetish</copyright>
+    <description>Library for adding XInput Gamepad (Windows 7 or Later) support to Buttplug Servers.</description>
+    <copyright>Copyright 2017 Nonpolynomial Labs, LLC</copyright>
     <dependencies>
       <dependency id="Buttplug.Core" version="0.0.0" />
       <dependency id="Buttplug.Server" version="0.0.0" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,31 @@
+# 0.1.1 (2017-09-15)
+
+## Features
+
+- Added auto update and update checking functionality
+- Added support for the following hardware
+  - WeVibe 4 Plus, Ditto, Nova, Pivot, Wish, Verge
+  - Lovense Domi
+- Added more product names for the Lovense Hush (LVS-Z36, LVS_Z001)
+- Added Game Vibration Router application
+- WebsocketServer now defaults to SSL
+
+## Bugfixes
+
+- SSL Errors in Websocket Server are now shown in GUI or as a notification, not in modal dialogs.
+- Fixed ObjectDisposed Exception in Kiiroo App
+- Fixed port number changing in Websocket Server
+- Fixed crash when copying IP addresses in Websocket Server
+- Fixed version number listing in logs
+
 # 0.1.0 (2017-08-07)
+
+## Features
 
 - First release
 - Added support for the following hardware
   - XInput (XBox) Gamepads
-  - Lovense Toys (vibration only)
+  - Lovense Max, Nora, Lush, Hush, Ambi, Edge (vibration only)
   - Fleshlight Launch
   - Vorze A10 Cyclone
   - Magic Motion toys

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Buttplug is covered under the following BSD 3-Clause License
 
-Copyright (c) 2017, Metafetish
+Copyright (c) 2017, Nonpolynomial Labs, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -68,32 +68,5 @@ write code for!
 
 ## License
 
-Buttplug is BSD licensed.
-
-    Copyright (c) 2016-2017, Metafetish
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-    
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-    
-    * Neither the name of buttplug nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-    
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Buttplug is BSD 3-Clause licensed. More information is available in
+the LICENSE file.


### PR DESCRIPTION
We're getting a lot of weird exceptions for Websockets even when the
connection works. This can lead to the notification toaster popping
constantly, which will confuse the user. Only pop the toaster if we
don't connect right after the exception is thrown.

Fixes #280