### PR TITLE
fix: Extend "not get" supression timer

### DIFF
--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml.cs
@@ -47,10 +47,10 @@ namespace Buttplug.Apps.WebsocketServerGUI
             _port = 12345;
 
             // Usually, if we throw errors then connect, it's not actually an error.
-            // If we don't connect after half a second of throwing an exception, pop the toaster, but not before then.
+            // If we don't connect after a second of throwing an exception, pop the toaster, but not before then.
             _toastTimer = new Timer
             {
-                Interval = 500,
+                Interval = 1000,
                 AutoReset = false,
                 Enabled = false,
             };


### PR DESCRIPTION
Currently the "not get" exception supression timer is 500ms, which is
apparently too slow for some cases. Up it to 1s.

Fixes #287