### PR TITLE
Explicitly add references to Windows RT API

### DIFF
--- a/Buttplug.Apps.KiirooEmulatorGUI/Buttplug.Apps.KiirooEmulatorGUI.csproj
+++ b/Buttplug.Apps.KiirooEmulatorGUI/Buttplug.Apps.KiirooEmulatorGUI.csproj
@@ -13,6 +13,7 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <targetplatformversion>8.0</targetplatformversion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -62,6 +63,8 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
+    <Reference Include="Windows.UI" />
+    <Reference Include="Windows.UI.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
+++ b/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
@@ -13,6 +13,7 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <targetplatformversion>8.0</targetplatformversion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -63,6 +64,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
     </Reference>
+    <Reference Include="Windows.Data" />
+    <Reference Include="Windows.Foundation" />
+    <Reference Include="Windows.UI" />
+    <Reference Include="Windows.UI.Xaml" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />


### PR DESCRIPTION
Fixes "namespace name 'UI' does not exist in the namespace 'Windows'" compile time errors.