### PR TITLE
feat: Add Cougar to WeVibe device name list

### DIFF
--- a/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
+++ b/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
@@ -24,6 +24,7 @@ namespace Buttplug.Server.Bluetooth.Devices
             "Pivot",
             "Wish",
             "Verge",
+            "Cougar",
         };
 
         public Guid[] Characteristics { get; } =


### PR DESCRIPTION
Yet another name for the WeVibe4.

Fixes #309