### PR TITLE
Adding an 'ignore cert errors' flag to the WSClient

### DIFF
--- a/Buttplug.Apps.ExampleClientGUI/ExampleClientPanel.xaml.cs
+++ b/Buttplug.Apps.ExampleClientGUI/ExampleClientPanel.xaml.cs
@@ -66,7 +66,7 @@ namespace Buttplug.Apps.ExampleClientGUI
             {
                 if (_client != null)
                 {
-                    await _client.Connect(new Uri(AdressTextBox.Text));
+                    await _client.Connect(new Uri(AdressTextBox.Text), true);
                     await _client.RequestDeviceList();
 
                     foreach (var dev in _client.getDevices())

--- a/Buttplug.Client.Test/ButtPlugClientTests.cs
+++ b/Buttplug.Client.Test/ButtPlugClientTests.cs
@@ -62,5 +62,40 @@ namespace Buttplug.Client.Test
             await client.Disconnect();
             server.StopServer();
         }
+
+        [Fact]
+        public async void TestSSLConnection()
+        {
+            var server = new ButtplugWebsocketServer();
+            server.StartServer(this, 12346, true, true);
+
+            var client = new ButtplugTestClient("Test client");
+            await client.Connect(new Uri("wss://localhost:12346/buttplug"), true);
+
+            var msgId = client.nextMsgId;
+            var res = await client.SendMsg(new Core.Messages.Test("Test string", msgId));
+            Assert.True(res != null);
+            Assert.True(res is Core.Messages.Test);
+            Assert.True(((Core.Messages.Test)res).TestString == "Test string");
+            Assert.True(((Core.Messages.Test)res).Id == msgId);
+
+            // Check ping is working
+            Thread.Sleep(400);
+
+            msgId = client.nextMsgId;
+            res = await client.SendMsg(new Core.Messages.Test("Test string", msgId));
+            Assert.True(res != null);
+            Assert.True(res is Core.Messages.Test);
+            Assert.True(((Core.Messages.Test)res).TestString == "Test string");
+            Assert.True(((Core.Messages.Test)res).Id == msgId);
+
+            Assert.True(client.nextMsgId > 4);
+
+            await client.RequestDeviceList();
+
+            // Shut it down
+            await client.Disconnect();
+            server.StopServer();
+        }
     }
 }

--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -103,7 +103,7 @@ namespace Buttplug.Client
             Disconnect().Wait();
         }
 
-        public async Task Connect(Uri aURL)
+        public async Task Connect(Uri aURL, bool aIgnoreSSLErrors = false)
         {
             if (_ws != null && (_ws.State == WebSocketState.Connecting || _ws.State == WebSocketState.Open))
             {
@@ -121,6 +121,12 @@ namespace Buttplug.Client
             _ws.Opened += OpenedHandler;
             _ws.Closed += ClosedHandler;
             _ws.Error += ErrorHandler;
+
+            if (aIgnoreSSLErrors)
+            {
+                _ws.Security.AllowNameMismatchCertificate = true;
+                _ws.Security.AllowUnstrustedCertificate = true;
+            }
 
             _ws.Open();
 

--- a/Buttplug.Components.WebsocketServer/CertUtils.cs
+++ b/Buttplug.Components.WebsocketServer/CertUtils.cs
@@ -102,6 +102,85 @@ namespace Buttplug.Components.WebsocketServer
             return x509;
         }
 
+        private static X509Certificate2 GenerateSelfSignedCertificate(string subject)
+        {
+            const int keyStrength = 2048;
+
+            // Generating Random Numbers
+            var randomGenerator = new CryptoApiRandomGenerator();
+            var random = new SecureRandom(randomGenerator);
+
+            // The Certificate Generator
+            var certificateGenerator = new X509V3CertificateGenerator();
+
+            // Serial Number
+            certificateGenerator.SetSerialNumber(BigIntegers.CreateRandomInRange(BigInteger.One, BigInteger.ValueOf(long.MaxValue), random));
+
+            // Subject Public Key
+            var keyPairGenerator = new RsaKeyPairGenerator();
+            var keyGenerationParameters = new KeyGenerationParameters(random, keyStrength);
+            keyPairGenerator.Init(keyGenerationParameters);
+            var subjectKeyPair = keyPairGenerator.GenerateKeyPair();
+            certificateGenerator.SetPublicKey(subjectKeyPair.Public);
+
+            // Subject DN
+            certificateGenerator.SetSubjectDN(new X509Name("CN=" + subject));
+
+            // Subject Alternative Name
+            var subjectAlternativeNames = new List<Asn1Encodable>()
+            {
+                new GeneralName(GeneralName.DnsName, Environment.MachineName),
+                new GeneralName(GeneralName.DnsName, "localhost"),
+                new GeneralName(GeneralName.IPAddress, "127.0.0.1"),
+            };
+
+            if (subject != "localhost" && subject != Environment.MachineName)
+            {
+                subjectAlternativeNames.Add(new GeneralName(GeneralName.DnsName, subject));
+            }
+
+            certificateGenerator.AddExtension(X509Extensions.SubjectAlternativeName.Id, false, new DerSequence(subjectAlternativeNames.ToArray()));
+
+            // Issuer
+            certificateGenerator.SetIssuerDN(new X509Name("CN=" + subject));
+            certificateGenerator.AddExtension(X509Extensions.SubjectKeyIdentifier.Id, false, new SubjectKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(subjectKeyPair.Public)));
+
+            // Valid For
+            var notBefore = DateTime.UtcNow.Date;
+            var notAfter = notBefore.AddYears(2);
+            certificateGenerator.SetNotBefore(notBefore);
+            certificateGenerator.SetNotAfter(notAfter);
+
+            // Add basic constraint
+            certificateGenerator.AddExtension(X509Extensions.BasicConstraints.Id, true, new BasicConstraints(false));
+
+            certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, false, new ExtendedKeyUsage(new[] { KeyPurposeID.IdKPServerAuth }));
+
+            // Signature Algorithm
+            const string signatureAlgorithm = "SHA256WithRSA";
+            var signatureFactory = new Asn1SignatureFactory(signatureAlgorithm, subjectKeyPair.Private);
+
+            // selfsign certificate
+            var certificate = certificateGenerator.Generate(signatureFactory);
+
+            // correcponding private key
+            var info = PrivateKeyInfoFactory.CreatePrivateKeyInfo(subjectKeyPair.Private);
+
+            // merge into X509Certificate2
+            var x509 = new X509Certificate2(certificate.GetEncoded());
+            var seq = (Asn1Sequence)Asn1Object.FromByteArray(info.ParsePrivateKey().GetDerEncoded());
+            if (seq.Count != 9)
+            {
+                // throw new PemException("malformed sequence in RSA private key");
+            }
+
+            var rsa = RsaPrivateKeyStructure.GetInstance(seq);
+            var rsaparams = new RsaPrivateCrtKeyParameters(
+                rsa.Modulus, rsa.PublicExponent, rsa.PrivateExponent, rsa.Prime1, rsa.Prime2, rsa.Exponent1, rsa.Exponent2, rsa.Coefficient);
+            x509.PrivateKey = ToDotNetKey(rsaparams); // x509.PrivateKey = DotNetUtilities.ToRSA(rsaparams);
+            return x509;
+        }
+
         private static AsymmetricAlgorithm ToDotNetKey(RsaPrivateCrtKeyParameters privateKey)
         {
             var cspParams = new CspParameters
@@ -186,18 +265,23 @@ namespace Buttplug.Components.WebsocketServer
             var appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), app);
             var caPfx = Path.Combine(appPath, "ca.pfx");
             var certPfx = Path.Combine(appPath, "cert.pfx");
-            if (!File.Exists(caPfx) || !File.Exists(certPfx))
+
+            // Patch release rework of cert handling: our websocket server doesn't acept a chain!
+            if (File.Exists(caPfx))
             {
-                AsymmetricCipherKeyPair caKeyPair = null;
-                var caCert = GenerateCACertificate("CN=" + app + "CA", ref caKeyPair);
-                var clientCert = GenerateSelfSignedCertificate(hostname, caCert, caKeyPair);
-                var p12ca = new X509Certificate2(caCert.Export(X509ContentType.Pfx), (string)null).Export(X509ContentType.Pfx);
+                File.Delete(caPfx);
+                if (File.Exists(certPfx))
+                {
+                    File.Delete(certPfx);
+                }
+            }
+
+            if (!File.Exists(certPfx))
+            {
+                var clientCert = GenerateSelfSignedCertificate(hostname);
                 var p12cert = clientCert.Export(X509ContentType.Pfx);
                 Directory.CreateDirectory(appPath);
-                var w = File.OpenWrite(caPfx);
-                w.Write(p12ca, 0, p12ca.Length);
-                w.Close();
-                w = File.OpenWrite(certPfx);
+                var w = File.OpenWrite(certPfx);
                 w.Write(p12cert, 0, p12cert.Length);
                 w.Close();
             }


### PR DESCRIPTION
This sets the ignore subject and ignore unknown certificates flags on WebSocket4Net.

Unfortunatly our WebSocketServer library does not allow for a X509Chain to be provided and WebSocket4Net requires
the chain to be valid (even if the root is self signed). To avoid this breaking us further, the cert generation now skips the CA and only gnerates a single self-signed cert. For upgrade purposes, any existing CA+Cert combos wil be removed.

Fixes #316