### PR TITLE
ButtplugWSClient::SendMessage() always increments the msgID

### DIFF
--- a/Buttplug.Client.Test/ButtPlugClientTests.cs
+++ b/Buttplug.Client.Test/ButtPlugClientTests.cs
@@ -42,7 +42,7 @@ namespace Buttplug.Client.Test
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
             Assert.True(((Core.Messages.Test)res).TestString == "Test string");
-            Assert.True(((Core.Messages.Test)res).Id == msgId);
+            Assert.True(((Core.Messages.Test)res).Id > msgId);
 
             // Check ping is working
             Thread.Sleep(400);
@@ -52,9 +52,15 @@ namespace Buttplug.Client.Test
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
             Assert.True(((Core.Messages.Test)res).TestString == "Test string");
-            Assert.True(((Core.Messages.Test)res).Id == msgId);
+            Assert.True(((Core.Messages.Test)res).Id > msgId);
 
-            Assert.True(client.nextMsgId > 4);
+            res = await client.SendMsg(new Core.Messages.Test("Test string"));
+            Assert.True(res != null);
+            Assert.True(res is Core.Messages.Test);
+            Assert.True(((Core.Messages.Test)res).TestString == "Test string");
+            Assert.True(((Core.Messages.Test)res).Id > msgId);
+
+            Assert.True(client.nextMsgId > 5);
 
             await client.RequestDeviceList();
 
@@ -77,7 +83,7 @@ namespace Buttplug.Client.Test
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
             Assert.True(((Core.Messages.Test)res).TestString == "Test string");
-            Assert.True(((Core.Messages.Test)res).Id == msgId);
+            Assert.True(((Core.Messages.Test)res).Id > msgId);
 
             // Check ping is working
             Thread.Sleep(400);
@@ -87,7 +93,7 @@ namespace Buttplug.Client.Test
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
             Assert.True(((Core.Messages.Test)res).TestString == "Test string");
-            Assert.True(((Core.Messages.Test)res).Id == msgId);
+            Assert.True(((Core.Messages.Test)res).Id > msgId);
 
             Assert.True(client.nextMsgId > 4);
 

--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 using Buttplug.Core;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
-using static Buttplug.Client.DeviceEventArgs;
-using WebSocket4Net;
 using SuperSocket.ClientEngine;
+using WebSocket4Net;
+using static Buttplug.Client.DeviceEventArgs;
 
 namespace Buttplug.Client
 {
@@ -305,7 +305,7 @@ namespace Buttplug.Client
         {
             try
             {
-                var msg = await SendMessage(new Ping(nextMsgId));
+                var msg = await SendMessage(new Ping());
                 if (msg is Error)
                 {
                     _owningDispatcher.Send(_ =>
@@ -326,7 +326,7 @@ namespace Buttplug.Client
 
         public async Task RequestDeviceList()
         {
-            var resp = await SendMessage(new RequestDeviceList(nextMsgId));
+            var resp = await SendMessage(new RequestDeviceList());
             if (!(resp is DeviceList) || (resp as DeviceList).Devices == null)
             {
                 if (resp is Error)
@@ -365,17 +365,17 @@ namespace Buttplug.Client
 
         public async Task<bool> StartScanning()
         {
-            return await SendMessageExpectOk(new StartScanning(nextMsgId));
+            return await SendMessageExpectOk(new StartScanning());
         }
 
         public async Task<bool> StopScanning()
         {
-            return await SendMessageExpectOk(new StopScanning(nextMsgId));
+            return await SendMessageExpectOk(new StopScanning());
         }
 
         public async Task<bool> RequestLog(string aLogLevel)
         {
-            return await this.SendMessageExpectOk(new RequestLog(aLogLevel, nextMsgId));
+            return await this.SendMessageExpectOk(new RequestLog(aLogLevel));
         }
 
         public async Task<ButtplugMessage> SendDeviceMessage(ButtplugClientDevice aDevice, ButtplugDeviceMessage aDeviceMsg)
@@ -403,6 +403,9 @@ namespace Buttplug.Client
 
         protected async Task<ButtplugMessage> SendMessage(ButtplugMessage aMsg)
         {
+            // The client always increments the IDs on outgoing messages
+            aMsg.Id = nextMsgId;
+
             var promise = new TaskCompletionSource<ButtplugMessage>();
             _waitingMsgs.TryAdd(aMsg.Id, promise);
 


### PR DESCRIPTION
This means consumers of the library do not need to manually set the message IDs at all now.

Fixes #318