### PR TITLE
ButtplugWSClient now requests the device list on connect

### DIFF
--- a/Buttplug.Apps.ExampleClientGUI/ExampleClientPanel.xaml.cs
+++ b/Buttplug.Apps.ExampleClientGUI/ExampleClientPanel.xaml.cs
@@ -68,9 +68,8 @@ namespace Buttplug.Apps.ExampleClientGUI
                 if (_client != null)
                 {
                     await _client.Connect(new Uri(AdressTextBox.Text), true);
-                    await _client.RequestDeviceList();
 
-                    foreach (var dev in _client.getDevices())
+                    foreach (var dev in _client.Devices)
                     {
                         devControl.DeviceAdded(new ButtplugDeviceInfo(dev.Index, dev.Name, dev.AllowedMessages));
                     }
@@ -142,7 +141,7 @@ namespace Buttplug.Apps.ExampleClientGUI
                         new FleshlightLaunchFW12Cmd(dev.Index,
                             Convert.ToUInt32(LinearSpeed.Value),
                             Convert.ToUInt32(LinearPosition.Value),
-                            _client.nextMsgId));
+                            _client.NextMsgId));
                 }
             }
         }
@@ -168,7 +167,7 @@ namespace Buttplug.Apps.ExampleClientGUI
                                 new VibrateCmd(dev.Index,
                                     new List<VibrateCmd.VibrateSubcommand>
                                     { new VibrateCmd.VibrateSubcommand(i, VibrateSpeed.Value) },
-                                    _client.nextMsgId));
+                                    _client.NextMsgId));
                         }
                     }
                     catch
@@ -200,7 +199,7 @@ namespace Buttplug.Apps.ExampleClientGUI
                                 new RotateCmd(dev.Index,
                                     new List<RotateCmd.RotateSubcommand>
                                             { new RotateCmd.RotateSubcommand(i, RotateSpeed.Value * (clockwise ? 1 : -1), clockwise) },
-                                    _client.nextMsgId));
+                                    _client.NextMsgId));
                         }
                     }
                     catch
@@ -227,7 +226,7 @@ namespace Buttplug.Apps.ExampleClientGUI
                             new LinearCmd.VectorSubcommands(0,
                                 Convert.ToUInt32(LinearDuration.Text),
                                 Linear2Position.Value),
-                        }, _client.nextMsgId));
+                        }, _client.NextMsgId));
                 }
             }
         }

--- a/Buttplug.Client.Test/ButtPlugClientTests.cs
+++ b/Buttplug.Client.Test/ButtPlugClientTests.cs
@@ -57,7 +57,7 @@ namespace Buttplug.Client.Test
         [Test]
         public void TestConnection()
         {
-            AutoResetEvent eEvent = new AutoResetEvent(false);
+            var eEvent = new AutoResetEvent(false);
 
             _subtypeMgr.AddDevice(new TestDevice(_logMgr, "A", "1"));
             _server = new ButtplugWebsocketServer();
@@ -66,7 +66,7 @@ namespace Buttplug.Client.Test
             _client = new ButtplugTestClient("Test client");
             _client.Connect(new Uri("ws://localhost:12345/buttplug")).Wait();
 
-            var msgId = _client.nextMsgId;
+            var msgId = _client.NextMsgId;
             var res = _client.SendMsg(new Core.Messages.Test("Test string", msgId)).GetAwaiter().GetResult();
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
@@ -76,7 +76,7 @@ namespace Buttplug.Client.Test
             // Check ping is working
             Thread.Sleep(400);
 
-            msgId = _client.nextMsgId;
+            msgId = _client.NextMsgId;
             res = _client.SendMsg(new Core.Messages.Test("Test string", msgId)).GetAwaiter().GetResult();
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
@@ -89,10 +89,10 @@ namespace Buttplug.Client.Test
             Assert.True(((Core.Messages.Test)res).TestString == "Test string");
             Assert.True(((Core.Messages.Test)res).Id > msgId);
 
-            Assert.True(_client.nextMsgId > 5);
+            Assert.True(_client.NextMsgId > 5);
 
             // Test that events are raised
-            bool scanningFinished = false;
+            var scanningFinished = false;
             ButtplugClientDevice lastAdded = null;
             ButtplugClientDevice lastRemoved = null;
             _client.ScanningFinished += (aSender, aArg) =>
@@ -126,12 +126,9 @@ namespace Buttplug.Client.Test
             eEvent.Reset();
             Assert.True(scanningFinished);
 
-            Assert.AreEqual(1, _client.getDevices().Length);
-            Assert.AreEqual("B", _client.getDevices()[0].Name);
-            _client.RequestDeviceList().Wait();
-            Assert.AreEqual(2, _client.getDevices().Length);
-            Assert.AreEqual("A", _client.getDevices()[0].Name);
-            Assert.AreEqual("B", _client.getDevices()[1].Name);
+            Assert.AreEqual(2, _client.Devices.Length);
+            Assert.AreEqual("A", _client.Devices[0].Name);
+            Assert.AreEqual("B", _client.Devices[1].Name);
 
             eEvent.Reset();
             Assert.Null(lastRemoved);
@@ -147,8 +144,8 @@ namespace Buttplug.Client.Test
             eEvent.Reset();
             Assert.NotNull(lastRemoved);
             Assert.AreEqual("B", lastRemoved.Name);
-            Assert.AreEqual(1, _client.getDevices().Length);
-            Assert.AreEqual("A", _client.getDevices()[0].Name);
+            Assert.AreEqual(1, _client.Devices.Length);
+            Assert.AreEqual("A", _client.Devices[0].Name);
 
             // Shut it down
             _client.Disconnect().Wait();
@@ -164,7 +161,7 @@ namespace Buttplug.Client.Test
             _client = new ButtplugTestClient("Test client");
             _client.Connect(new Uri("wss://localhost:12346/buttplug"), true).Wait();
 
-            var msgId = _client.nextMsgId;
+            var msgId = _client.NextMsgId;
             var res = _client.SendMsg(new Core.Messages.Test("Test string", msgId)).GetAwaiter().GetResult();
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
@@ -174,16 +171,14 @@ namespace Buttplug.Client.Test
             // Check ping is working
             Thread.Sleep(400);
 
-            msgId = _client.nextMsgId;
+            msgId = _client.NextMsgId;
             res = _client.SendMsg(new Core.Messages.Test("Test string", msgId)).GetAwaiter().GetResult();
             Assert.True(res != null);
             Assert.True(res is Core.Messages.Test);
             Assert.True(((Core.Messages.Test)res).TestString == "Test string");
             Assert.True(((Core.Messages.Test)res).Id > msgId);
 
-            Assert.True(_client.nextMsgId > 4);
-
-            _client.RequestDeviceList().Wait();
+            Assert.True(_client.NextMsgId > 4);
 
             // Shut it down
             _client.Disconnect().Wait();


### PR DESCRIPTION
This means that during Connect() any devices already connected to the buttplug server will cause DeviceAdded events to be fired. This will include any devices that may have already been seen in the case of a reconnect (if the connection has dropped anything could have happened to the server, therefore the device list is purged and all devices are readded from scratch). As this is now called for you, the RequestDeviceList() method has been removed.

The internal device list is now accessible via a C# style getter Devices rather than the previous getDevices() method.

The nextMsgId getter has also been renamed to NextMsgId for consistency.