### PR TITLE
Correcting a dependency clash in the Buttplug.Client package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 /raven-csharp/
 /websocket-sharp/
 *.DotSettings.user
+*/Properties/PublishProfiles

--- a/Buttplug.Client/Buttplug.Client.csproj
+++ b/Buttplug.Client/Buttplug.Client.csproj
@@ -38,12 +38,7 @@
     <PackageReference Include="Microsoft.CSharp" version="4.4.1" />
     <PackageReference Include="NLog" version="4.5.0-rc03" />
     <PackageReference Include="StyleCop.Analyzers" version="1.1.0-beta004" PrivateAssets="All" />
-    <PackageReference Include="SuperSocket.ClientEngine" Version="0.8.0.13" />
-    <PackageReference Include="WebSocket4Net" Version="0.15.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Net.WebSockets.Client" version="4.3.1" />
+    <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -108,6 +108,7 @@ namespace Buttplug.Client
             {
                 _ws.Security.AllowNameMismatchCertificate = true;
                 _ws.Security.AllowUnstrustedCertificate = true;
+                _ws.Security.AllowCertificateChainErrors = true;
             }
 
             _ws.Open();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ install:
   - set
   - ps: get-childitem c:\tools\nunit3 -rec | where {!$_.PSIsContainer} | select-object FullName
   - ps: choco install -y -r --no-progress resharper-clt.portable
-  - ps: choco install -y -r --no-progress fxcop
   - ps: choco install -y -r --no-progress InnoSetup
   - ps: |
       function gitVersion() {


### PR DESCRIPTION
At some point, between WebSocket4Net 0.15.0 and 0.15.2, the dependency on SuperSocket.ClientEngine moved to SuperSocket.ClientEngine.Core (a straight rename), which meant that because we were still dependent of SuperSocket.ClientEngine we got 2 conflicting libraries.

Removing our explicit dependency on SuperSocket.ClientEngine means we now get whatever WebSocket4Net needs and no more.
