### PR TITLE
chore: Add LVS-Edge38 as new device name

### DIFF
--- a/Buttplug.Server/Bluetooth/Devices/Lovense.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Lovense.cs
@@ -197,8 +197,8 @@ namespace Buttplug.Server.Bluetooth.Devices
 
         public string[] Names { get; } =
         {
-            // Edge. Again.
             "LVS-Edge37",
+            "LVS-Edge38",
         };
 
         public Guid[] Characteristics { get; } =
@@ -267,6 +267,7 @@ namespace Buttplug.Server.Bluetooth.Devices
             { "LVS-Domi39", "Domi" },
             { "LVS-P36", "Edge" },
             { "LVS-Edge37", "Edge" },
+            { "LVS-Edge38", "Edge" },
         };
 
         private readonly uint _vibratorCount = 1;


### PR DESCRIPTION
Lovense sure does love changing device names.

Fixes #348