### PR TITLE
feat: Onyx2 support

### DIFF
--- a/Buttplug.Server.Test/Bluetooth/Devices/KiirooOnyx2Tests.cs
+++ b/Buttplug.Server.Test/Bluetooth/Devices/KiirooOnyx2Tests.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using Buttplug.Core.Messages;
+using Buttplug.Server.Bluetooth.Devices;
+using Buttplug.Server.Test.Util;
+using JetBrains.Annotations;
+using NUnit.Framework;
+
+namespace Buttplug.Server.Test.Bluetooth.Devices
+{
+    [TestFixture]
+    public class KiirooOnyx2Tests
+    {
+        [NotNull]
+        private BluetoothDeviceTestUtils<KiirooOnyx2BluetoothInfo> testUtil;
+
+        [SetUp]
+        public void Init()
+        {
+            testUtil = new BluetoothDeviceTestUtils<KiirooOnyx2BluetoothInfo>();
+            testUtil.SetupTest("Onyx2");
+        }
+
+        [Test]
+        public void TestAllowedMessages()
+        {
+            testUtil.TestDeviceAllowedMessages(new Dictionary<System.Type, uint>()
+            {
+                { typeof(StopDeviceCmd), 0 },
+                { typeof(FleshlightLaunchFW12Cmd), 0 },
+                { typeof(LinearCmd), 1 },
+            });
+        }
+
+        [Test]
+        public void TestInitialize()
+        {
+            testUtil.TestDeviceInitialize(new List<(byte[], uint)>()
+            {
+                (new byte[1] { 0x0 }, (uint)KiirooOnyx2BluetoothInfo.Chrs.Cmd),
+            }, true);
+        }
+
+        // StopDeviceCmd test handled in GeneralDeviceTests
+
+        // In all device message tests, expect WriteWithResponse to be false.
+        [Test]
+        public void TestFleshlightLaunchFW12Cmd()
+        {
+            testUtil.TestDeviceMessage(new FleshlightLaunchFW12Cmd(4, 50, 50),
+                new List<(byte[], uint)>()
+                {
+                    (new byte[2] { 50, 50 }, (uint)KiirooOnyx2BluetoothInfo.Chrs.Tx),
+                }, false);
+        }
+
+        // TODO Test currently fails because we will send repeated packets to the launch. See #402.
+        /*
+        [Test]
+        public void TestRepeatedFleshlightLaunchFW12Cmd()
+        {
+            testUtil.TestDeviceMessage(new FleshlightLaunchFW12Cmd(4, 50, 50),
+                new List<byte[]>()
+                {
+                    new byte[2] { 50, 50 },
+                }, (uint)FleshlightLaunchBluetoothInfo.Chrs.Tx, false);
+            testUtil.TestDeviceMessageNoop(new FleshlightLaunchFW12Cmd(4, 50, 50));
+        }
+        */
+
+        [Test]
+        public void TestVectorCmd()
+        {
+            var msg = new LinearCmd(4, new List<LinearCmd.VectorSubcommand>
+            {
+                new LinearCmd.VectorSubcommand(0, 500, 0.5),
+            });
+            testUtil.TestDeviceMessage(msg,
+                new List<(byte[], uint)>()
+                {
+                    (new byte[2] { 50, 20 }, (uint)KiirooOnyx2BluetoothInfo.Chrs.Tx),
+                }, false);
+        }
+
+        [Test]
+        public void TestInvalidVectorCmdTooManyFeatures()
+        {
+            var msg = LinearCmd.Create(4, 0, 500, 0.75, 2);
+            testUtil.TestInvalidDeviceMessage(msg);
+        }
+
+        [Test]
+        public void TestInvalidVectorCmdWrongFeatures()
+        {
+            var msg = new LinearCmd(4,
+                new List<LinearCmd.VectorSubcommand>
+                {
+                    new LinearCmd.VectorSubcommand(0xffffffff, 500, 0.75),
+                });
+            testUtil.TestInvalidDeviceMessage(msg);
+        }
+
+        [Test]
+        public void TestInvalidVectorNotEnoughFeatures()
+        {
+            var msg = LinearCmd.Create(4, 0, 500, 0.75, 0);
+            testUtil.TestInvalidDeviceMessage(msg);
+        }
+    }
+}

--- a/Buttplug.Server.Test/Buttplug.Server.Test.csproj
+++ b/Buttplug.Server.Test/Buttplug.Server.Test.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Compile Include="ArgsTests.cs" />
     <Compile Include="AssemblyGitVersionTests.cs" />
+    <Compile Include="Bluetooth\Devices\KiirooOnyx2Tests.cs" />
     <Compile Include="Bluetooth\Devices\FleshlightLaunchTests.cs" />
     <Compile Include="Bluetooth\Devices\GeneralDeviceTests.cs" />
     <Compile Include="Bluetooth\Devices\KiirooGen2VibeTests.cs" />

--- a/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
+++ b/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
@@ -22,6 +22,7 @@ namespace Buttplug.Server.Bluetooth
                 new FleshlightLaunchBluetoothInfo(),
                 new KiirooBluetoothInfo(),
                 new KiirooGen2VibeBluetoothInfo(),
+                new KiirooOnyx2BluetoothInfo(),
                 new YoucupsBluetoothInfo(),
                 new LovenseBluetoothInfo(),
                 new MagicMotionBluetoothInfo(),


### PR DESCRIPTION
It turns out the protocol for the Onyx2 is identical to the
Fleshlight Launch, with the exception that the handshake
byte is written to the Cmd handle instead of the Tx.

This adds the characteristic set to the existing Launch
protocol class rather than duplicating it.

Fixes #320